### PR TITLE
Fix Trans component  when index is incorrect

### DIFF
--- a/__tests__/Trans.test.js
+++ b/__tests__/Trans.test.js
@@ -95,5 +95,22 @@ describe('Trans', () => {
       expect(container.textContent).toContain(expectedText)
       expect(container.innerHTML).toContain(expectedHTML)
     })
+
+    test('should work without replacing the HTMLElement if the index is incorrectly', () => {
+      const i18nKey = 'common:test-html'
+      const expectedHTML = "test with link."
+      const common = {   
+        "test-html": "test <10>with link</10>.",
+      }
+
+      const { container } = render(
+        <TestEnglish 
+          namespaces={{ common }} 
+          i18nKey={i18nKey} 
+          components={[<b />]}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
   })
 })

--- a/__tests__/Trans.test.js
+++ b/__tests__/Trans.test.js
@@ -98,9 +98,9 @@ describe('Trans', () => {
 
     test('should work without replacing the HTMLElement if the index is incorrectly', () => {
       const i18nKey = 'common:test-html'
-      const expectedHTML = "test with link."
+      const expectedHTML = "test with bad index."
       const common = {   
-        "test-html": "test <10>with link</10>.",
+        "test-html": "test <10>with bad index</10>.",
       }
 
       const { container } = render(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-translate",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Next.js utility to translate pages without the need of a server (static i18n pages generator).",
   "license": "MIT",
   "keywords": [

--- a/src/Trans.js
+++ b/src/Trans.js
@@ -1,4 +1,4 @@
-import { cloneElement, useMemo } from 'react'
+import { cloneElement, useMemo, Fragment } from 'react'
 import useTranslation from './useTranslation'
 
 const tagRe = /<(\d+)>(.*?)<\/\1>|<(\d+)\/>/
@@ -28,7 +28,8 @@ function formatElements(
   if (before) tree.push(before)
 
   for (const [index, children, after] of getElements(parts)) {
-    const element = elements[index]
+    const element = elements[index] || <Fragment />
+
     tree.push(
       cloneElement(
         element,

--- a/src/appWithI18n.js
+++ b/src/appWithI18n.js
@@ -2,7 +2,7 @@ import React from 'react'
 import I18nProvider from './I18nProvider'
 
 function getLang(ctx, config) {
-  const { req, asPath } = ctx
+  const { req, asPath = '' } = ctx
 
   if (req) return req.query.lang || config.defaultLanguage
 


### PR DESCRIPTION
When the index is not correct:

```json
{   
     "test-html": "test <10>with link</10>.",
}
```

And we call the Trans as:

```js
<Trans
   i18nKey={i18nKey} 
   components={[<b />]}
/>
```

Was getting an error because the index didn't correspond. Now if the index doesn't correspond, it's just going to be a Fragment for all these incorrect indexes, without a crash.