### PR TITLE
Export all from page exports

### DIFF
--- a/cli/builder.js
+++ b/cli/builder.js
@@ -96,6 +96,8 @@ export default function Page(p){
 }
 
 Page = Object.assign(Page, { ...C })
+
+export * from '${prefix}/${clearPageExt(page)}'
 `
 }
 

--- a/examples/static-site/pages_/index.tsx
+++ b/examples/static-site/pages_/index.tsx
@@ -6,10 +6,13 @@ import useTranslation from 'next-translate/useTranslation'
 // @ts-ignore
 import Header from '../components/header'
 
-export default function Home() {
+// @ts-ignore
+export default function Home(props) {
   const { t, lang } = useTranslation()
   const description = t('home:description')
   const linkName = t('home:more-examples')
+
+  console.log(props)
 
   return (
     <>
@@ -21,3 +24,7 @@ export default function Home() {
     </>
   )
 }
+
+export const getStaticProps = async () => ({
+  props: { getStaticPropsWorks: true },
+})

--- a/examples/with-server/components/header.js
+++ b/examples/with-server/components/header.js
@@ -3,7 +3,7 @@ import Head from 'next/Head'
 import Link from 'next/link'
 import useTranslation from 'next-translate/useTranslation'
 
-import styles from 'header.module.css'
+import styles from './header.module.css'
 
 export default function Header() {
   const { t, lang } = useTranslation()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-translate",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Next.js utility to translate pages without the need of a server (static i18n pages generator).",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
@BjoernRave When the new release of `next.js` was made, it was adapted to instead of support only `Page.getInitialProps`, to support whatever via `Page.whatEver`, with the idea to allow the new methods: `getServerSideProps`, `getStaticProps`, `getStaticPaths`. However, these methods are defined differently, they are just export with a normal `export`.

In order to fix the support of these new methods. I added the:

```js
export * from '${prefix}/${clearPageExt(page)}'
```

To export all from page exports. In this way, also we are covered to coming features as `export function Head() {}` or others.  