### PR TITLE
Fix error when Router options is undefined

### DIFF
--- a/__tests__/Router.test.js
+++ b/__tests__/Router.test.js
@@ -104,4 +104,20 @@ describe('Router', () => {
       })
     })
   })
+
+  test('should work without specifying a language', () => {
+    function nav() {
+      Router.pushI18n('/some/route')
+    }
+    function Component() {
+      return (
+        <I18nProvider lang="en" namespaces={{}} isStaticMode>
+          <button onClick={nav}>Navigate</button>
+        </I18nProvider>
+      )
+    }
+    const { container } = render(<Component />)
+    fireEvent.click(container.firstChild)
+    expectNavigation({ href: '/en/some/route', as: undefined })
+  })
 })

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,7 +3,7 @@ import clientSideLang from './clientSideLang'
 import fixAs from './_helpers/fixAs'
 import fixHref from './_helpers/fixHref'
 
-const nav = ev => (a1, a2, a3) => {
+const nav = ev => (a1, a2, a3 = {}) => {
   const a1IsObj = typeof a1 === 'object'
   const url = a1IsObj ? a1.url : a1
   const as = a1IsObj ? a1.as : a2


### PR DESCRIPTION
You can verify the problem by running the test without the fix. It will cause an error. Existing tests didn't catch it because they way they are written, `options` will always be defined.

Feel free to change the test to match your style. I mostly added it to prove that there was a problem that needed to be fixed.