### PR TITLE
refactor: update next imports to avoid error on Linux (Ubuntu based)

### DIFF
--- a/examples/static-site/components/header.js
+++ b/examples/static-site/components/header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Head from 'next/Head'
+import Head from 'next/head'
 import Link from 'next-translate/Link'
 import Router from 'next-translate/Router'
 import useTranslation from 'next-translate/useTranslation'

--- a/examples/with-server/components/header.js
+++ b/examples/with-server/components/header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Head from 'next/Head'
+import Head from 'next/head'
 import Link from 'next-translate/Link'
 import useTranslation from 'next-translate/useTranslation'
 


### PR DESCRIPTION
I was trying to run the examples on my Linux Mint (19.3) when I got same error [reported here](https://github.com/zeit/next.js/issues/9482).

See also: https://github.com/zeit/next.js/issues/9482