### PR TITLE
Add tests to Link utils

### DIFF
--- a/__tests__/fixAs.test.js
+++ b/__tests__/fixAs.test.js
@@ -1,0 +1,24 @@
+import fixAs from '../src/fixAs'
+import { setInternals } from '../src/_helpers/_internals'
+
+function cleanup() {
+  setInternals({
+    defaultLangRedirect: undefined,
+    defaultLanguage: undefined,
+    isStaticMode: undefined,
+  })
+}
+
+describe('fixAs', () => {
+  afterEach(cleanup)
+
+  test('return the correct asPath', () => {
+    setInternals({
+      defaultLanguage: 'en',
+    })
+    expect(fixAs('/homepage', '/', 'en')).toBe('/homepage')
+    expect(fixAs('/homepage/', '/', 'en')).toBe('/homepage/')
+    expect(fixAs('/homepage', '/', 'it')).toBe('/it/homepage')
+    expect(fixAs('/homepage/', '/', 'it')).toBe('/it/homepage/')
+  })
+})

--- a/__tests__/fixHref.test.js
+++ b/__tests__/fixHref.test.js
@@ -1,0 +1,32 @@
+import fixHref from '../src/fixHref'
+import { setInternals } from '../src/_helpers/_internals'
+
+function cleanup() {
+  setInternals({
+    defaultLangRedirect: undefined,
+    defaultLanguage: undefined,
+    isStaticMode: undefined,
+  })
+}
+
+describe('fixHref', () => {
+  afterEach(cleanup)
+
+  test('add lang query parameter to pathname', () => {
+    setInternals({
+      defaultLanguage: 'en',
+    })
+    expect(fixHref('/homepage', 'en')).toBe('/homepage?lang=en')
+    expect(fixHref('/homepage/', 'en')).toBe('/homepage/?lang=en')
+    expect(fixHref('/homepage?foo=baz', 'en')).toBe('/homepage?foo=baz&lang=en')
+    expect(fixHref('/homepage/?foo=baz', 'en')).toBe(
+      '/homepage/?foo=baz&lang=en'
+    )
+    expect(fixHref('/homepage', 'it')).toBe('/homepage?lang=it')
+    expect(fixHref('/homepage/', 'it')).toBe('/homepage/?lang=it')
+    expect(fixHref('/homepage?foo=baz', 'it')).toBe('/homepage?foo=baz&lang=it')
+    expect(fixHref('/homepage/?foo=baz', 'it')).toBe(
+      '/homepage/?foo=baz&lang=it'
+    )
+  })
+})


### PR DESCRIPTION
Add some tests for utils used in `Link` to check correct creation of `as` and `href` props passed to `next/link`
This should check the use case of `trailingSlash` option mentioned in #248.
It does not close the issue, but add evidence to an issue related `next/link`
