### PR TITLE
Allow Anchors / Hashes in URL paths

### DIFF
--- a/__tests__/fixAs.test.js
+++ b/__tests__/fixAs.test.js
@@ -20,5 +20,15 @@ describe('fixAs', () => {
     expect(fixAs('/homepage/', '/', 'en')).toBe('/homepage/')
     expect(fixAs('/homepage', '/', 'it')).toBe('/it/homepage')
     expect(fixAs('/homepage/', '/', 'it')).toBe('/it/homepage/')
+    expect(fixAs('/homepage#anchor', '/#anchor', 'en')).toBe('/homepage#anchor')
+    expect(fixAs('/homepage/#anchor', '/#anchor', 'en')).toBe(
+      '/homepage/#anchor'
+    )
+    expect(fixAs('/homepage#anchor', '/#anchor', 'it')).toBe(
+      '/it/homepage#anchor'
+    )
+    expect(fixAs('/homepage/#anchor', '/#anchor', 'it')).toBe(
+      '/it/homepage/#anchor'
+    )
   })
 })

--- a/__tests__/fixHref.test.js
+++ b/__tests__/fixHref.test.js
@@ -29,4 +29,27 @@ describe('fixHref', () => {
       '/homepage/?foo=baz&lang=it'
     )
   })
+  test('arrange query string before hash', () => {
+    setInternals({
+      defaultLanguage: 'en',
+    })
+    expect(fixHref('/#anchor', 'en')).toBe('/?lang=en#anchor')
+    expect(fixHref('/homepage#anchor', 'en')).toBe('/homepage?lang=en#anchor')
+    expect(fixHref('/homepage/#anchor', 'en')).toBe('/homepage/?lang=en#anchor')
+    expect(fixHref('/homepage?foo=baz#anchor', 'en')).toBe(
+      '/homepage?foo=baz&lang=en#anchor'
+    )
+    expect(fixHref('/homepage/?foo=baz#anchor', 'en')).toBe(
+      '/homepage/?foo=baz&lang=en#anchor'
+    )
+    expect(fixHref('/#anchor', 'it')).toBe('/?lang=it#anchor')
+    expect(fixHref('/homepage#anchor', 'it')).toBe('/homepage?lang=it#anchor')
+    expect(fixHref('/homepage/#anchor', 'it')).toBe('/homepage/?lang=it#anchor')
+    expect(fixHref('/homepage?foo=baz#anchor', 'it')).toBe(
+      '/homepage?foo=baz&lang=it#anchor'
+    )
+    expect(fixHref('/homepage/?foo=baz#anchor', 'it')).toBe(
+      '/homepage/?foo=baz&lang=it#anchor'
+    )
+  })
 })

--- a/__tests__/startsWithLang.test.js
+++ b/__tests__/startsWithLang.test.js
@@ -1,0 +1,21 @@
+import startsWithLang from '../src/_helpers/startsWithLang'
+
+describe('startsWithLang', () => {
+  test('returns true if url starts with lang', () => {
+    expect(startsWithLang('/en', ['en', 'es'])).toBe(true)
+    expect(startsWithLang('/es', ['en', 'es'])).toBe(true)
+    expect(startsWithLang('/en/page', ['en', 'es'])).toBe(true)
+    expect(startsWithLang('/es/page', ['en', 'es'])).toBe(true)
+    expect(startsWithLang('/en#anchor', ['en', 'es'])).toBe(true)
+    expect(startsWithLang('/es#anchor', ['en', 'es'])).toBe(true)
+  })
+
+  test('returns false if url does not start with lang', () => {
+    expect(startsWithLang('/', ['en', 'es'])).toBe(false)
+    expect(startsWithLang('/', ['en', 'es'])).toBe(false)
+    expect(startsWithLang('/page', ['en', 'es'])).toBe(false)
+    expect(startsWithLang('/page', ['en', 'es'])).toBe(false)
+    expect(startsWithLang('/#anchor', ['en', 'es'])).toBe(false)
+    expect(startsWithLang('/#anchor', ['en', 'es'])).toBe(false)
+  })
+})

--- a/src/_helpers/startsWithLang.js
+++ b/src/_helpers/startsWithLang.js
@@ -1,5 +1,5 @@
 export default function startsWithLang(url, allLanguages) {
   return allLanguages.some((l) =>
-    new RegExp(`(^\/${l}\/)|(^\/${l}$)`).test(url)
+    new RegExp(`(^\/${l}\/)|(^\/${l}$)|(^\/${l}#.*$)`).test(url)
   )
 }

--- a/src/appWithI18n.js
+++ b/src/appWithI18n.js
@@ -10,9 +10,15 @@ function getLang(ctx, config) {
 
   if (req) return req.query.lang || config.defaultLanguage
 
-  return startsWithLang(asPath, config.allLanguages)
-    ? asPath.split('/')[1]
-    : config.defaultLanguage
+  if (startsWithLang(asPath, config.allLanguages)) {
+    if (asPath.includes('#')) {
+      return asPath.replace(/#[\w-]+/, '').split('/')[1]
+    }
+
+    return asPath.split('/')[1]
+  }
+
+  return config.defaultLanguage
 }
 
 function removeTrailingSlash(path = '') {

--- a/src/fixHref.js
+++ b/src/fixHref.js
@@ -1,6 +1,10 @@
 import i from './_helpers/_internals'
 import appendLangPrefix from './_helpers/appendLangPrefix'
 
+function includeLang(url, lng) {
+  return url.includes('?') ? `${url}&lang=${lng}` : `${url}?lang=${lng}`
+}
+
 export default (href, lng) => {
   const isRoot =
     i.defaultLangRedirect !== 'lang-path' && i.defaultLanguage === lng
@@ -8,5 +12,10 @@ export default (href, lng) => {
 
   if (i.isStaticMode) return url
 
-  return url.includes('?') ? `${url}&lang=${lng}` : `${url}?lang=${lng}`
+  if (url.includes('#')) {
+    const split = url.split('#')
+    return [includeLang(split[0], lng), split[1]].join('#')
+  }
+
+  return includeLang(url, lng)
 }


### PR DESCRIPTION
Closes #264 

## Changes
- Modify `fixHref` to handle # in url path correctly. Add tests.
- Update `fixAs` tests to also assert handling of # in url
- Fix `startsWithLang` - it currently is unable to recognise the language if there is a # in the url.
- Add tests for `startsWithLang`
- Fix `getLang` not handling hash in url path