### PR TITLE
Ignore copy css file

### DIFF
--- a/cli/builder.js
+++ b/cli/builder.js
@@ -281,7 +281,7 @@ function buildPageInAllLocales(pagePath, namespaces) {
   }
 
   // _app.js , _document.js, _error.js, /api/*, .css, .scss
-  if (isNextInternal(pagePath) || pagePath.match(/\.s?css$/)) {
+  if (isNextInternal(pagePath)) {
     if (pagePath.includes('/api/')) {
       fs.mkdirSync(`${finalPagesDir}/api`, { recursive: true })
       copyFolderRecursiveSync(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9281080/95702972-16057f80-0c78-11eb-82a7-f6d0b2de9cf7.png)
Fix bug can not copy style file to build folder (.css, .scss files)

We no longer need to copy styles file to destination folder as `Nextjs` document said that we can put style file anywhere.

Impact on current build: None