### PR TITLE
Add logger to config

### DIFF
--- a/cli/builder.js
+++ b/cli/builder.js
@@ -3,6 +3,14 @@ const fs = require('fs')
 const path = require('path')
 const getPageNamespaces = require('../_helpers/getPageNamespaces').default
 
+let configFile = {}
+
+if (fs.existsSync(process.cwd() + '/i18n.js')) {
+  configFile = require(process.cwd() + '/i18n.js')
+} else if (fs.existsSync(process.cwd() + '/i18n.json')) {
+  configFile = require(process.cwd() + '/i18n.json')
+}
+
 let {
   allLanguages = [],
   currentPagesDir = 'pages_',
@@ -11,9 +19,10 @@ let {
   finalPagesDir = 'pages',
   localesPath = 'locales',
   pages = {},
+  logger,
   redirectToDefaultLang: _deprecated_redirectToDefaultLang,
   logBuild = true,
-} = require(process.cwd() + '/i18n.json') || {}
+} = configFile
 
 const indexFolderRgx = /\/index\/index\....?$/
 const allPages = readDirR(currentPagesDir)
@@ -223,6 +232,7 @@ export default function Page(p){
       lang="${lang}" 
       namespaces={namespaces}  
       internals={${internals}}
+      ${typeof logger === 'function' && `logger={${logger.toString()}}`}
     >
       <C {...p} />
     </I18nProvider>

--- a/src/documentLang.js
+++ b/src/documentLang.js
@@ -3,8 +3,11 @@ const fs = require('fs')
 
 export default function documentLang({ __NEXT_DATA__ }, config) {
   if (!config) {
-    const configDir = path.join(process.cwd(), 'i18n.json')
-    config = JSON.parse(fs.readFileSync(configDir))
+    const file = fs.existsSync(process.cwd() + '/i18n.js')
+      ? 'i18n.js'
+      : 'i18n.json'
+
+    config = require(path.join(process.cwd(), file))
   }
 
   const { page } = __NEXT_DATA__


### PR DESCRIPTION
Closes https://github.com/vinissimus/next-translate/issues/237

CC: @giovannigiordano, @RobinSCU

It will be necessary to add the necessary documentation in the README.

There are two important changes:

- Now not only `i18n.json` is supported, but now `i18n.js` is also supported as a configuration file, so you can have functions in the configuration, as is the case with the logger.
- You can now pass `logger` to the configuration, as a function. If this function exists, it is executed in both development and production, and it is the responsibility of the implementer to make sure that their code is executed where is necessary. However, if `logger` is not passed in the configuration will run the default logger that only runs in development showing the `console.warn` as before.

