### PR TITLE
feat(builder): ignore test files in builder

### DIFF
--- a/__tests__/builder.test.js
+++ b/__tests__/builder.test.js
@@ -63,6 +63,14 @@ describe('builder', () => {
         fs.existsSync('examples/static-site/pages/es/more-examples/index.js')
       ).toBe(true)
 
+      // should ignore test files
+      expect(
+        fs.existsSync('examples/static-site/pages_/__tests__/dashboard.spec.js')
+      ).toBe(true)
+      expect(
+        fs.existsSync('examples/static-site/pages/__tests__/dashboard.spec.js')
+      ).toBe(false)
+
       // The default language should be not generated when defaultLangRedirect != 'lang-path'
       expect(fs.existsSync('examples/static-site/pages/en/index.js')).toBe(
         false

--- a/cli/builder.js
+++ b/cli/builder.js
@@ -25,6 +25,7 @@ let {
 } = configFile
 
 const indexFolderRgx = /\/index\/index\....?$/
+const specFileOrFolderRgx = /(__mocks__|__tests__)|(\.(spec|test)\.(tsx|ts|js|jsx)$)/
 const allPages = readDirR(currentPagesDir)
 
 // @todo 1.0.0 Remove this backwards compatibility.
@@ -282,6 +283,11 @@ function buildPageInAllLocales(pagePath, namespaces) {
     .join('/')
 
   let rootPrefix = prefix.replace('/..', '')
+
+  // ignore tests files
+  if (pagePath.match(specFileOrFolderRgx)) {
+    return
+  }
 
   // Rest one path if is index folder /index/index.js is going to
   // be generated directly as /index.js

--- a/examples/static-site/pages_/__tests__/dashboard.spec.js
+++ b/examples/static-site/pages_/__tests__/dashboard.spec.js
@@ -1,0 +1,7 @@
+import Dashboard from '../dashboard'
+
+describe('Dashboard', () => {
+  it('should return', () => {
+    expect(Dashboard()).toBe('just to test')
+  })
+})


### PR DESCRIPTION
Hi!
I just stumbled upon an issue when i tried to add tests to my "pages_/"-folder whether as plain files (e.g. "pages_/test.spec.tsx") or in a "pages_/__tests__"-folder, because next-translate tries to build them.
I created a regexr example for the ["specFileOrFolderRgx"-Regex](https://regexr.com/5eu6c)

This PR is the most basic implementation to solve this issue, suggestion are welcome!

Things i could also add:
- add real jest tests to the "examples/static-site"
- create files in the "examples/static-site" or a new example project to cover all cases for the new "specFileOrFolderRgx"-Regex
- create a tests just for the regex