### PR TITLE
Fix builder problem with group exports

### DIFF
--- a/cli/builder.js
+++ b/cli/builder.js
@@ -214,8 +214,13 @@ ${exports}
 }
 
 function hasExportName(data, name) {
-  return data.match(
-    new RegExp(`export (const|var|let|async function|function) ${name}`)
+  return (
+    data.match(
+      new RegExp(`export (const|var|let|async function|function) ${name}`)
+    ) ||
+    data.match(
+      new RegExp(`export\\s*\\{[^}]*(?<!\\w)${name}(?!\\w)[^}]*\\}`, 'm')
+    )
   )
 }
 


### PR DESCRIPTION
This fixes an issue where the builder can not find group exports such as getStaticProps and getStaticPaths.

```js
//  these are not detected!
export { getStaticProps, getStaticPaths }
```