### PR TITLE
TypeScript: Mark t()'s second parameter as optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface TranslationQuery {
 export interface Translate {
   (
     i18nKey: string,
-    query: TranslationQuery,
+    query?: TranslationQuery,
     options?: { returnObjects?: boolean }
   ): unknown
 }


### PR DESCRIPTION
Follow-up to https://github.com/vinissimus/next-translate/pull/302 (thanks for that!) fixing the second parameter of `t()` not being optional.