### PR TITLE
Improve return type of `Translate` #306

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,14 @@ export interface TranslationQuery {
 export interface Translate {
   (
     i18nKey: string,
-    query?: TranslationQuery,
-    options?: { returnObjects?: boolean }
-  ): unknown
+    query?: TranslationQuery | null,
+    options?: { returnObjects: false }
+  ): string
+  <R = unknown>(
+    i18nKey: string,
+    query: TranslationQuery | null | undefined,
+    options: { returnObjects: true }
+  ): R
 }
 
 export interface I18n {


### PR DESCRIPTION
The return type of the `t()` function is `unknown`, so we might have to cast it with `as Type`.

This is so cumbersome that I've improved the type of the `t()` function to use function overloading to estimate a type of the return value a little smarter.
Also, if you specify the returnObjects option, you need to write the type to generic as follows:

```typescript
t<Type>("key" , null ,  { returnObjects: true })
```