### PR TITLE
Add migration guide `0.x` to `1.0.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ yarn-error.log*
 *
 !.github
 !docs
+!docs/*
 !*.json
 !*.js
 !*.ts

--- a/docs/migration-guide-1.0.0.md
+++ b/docs/migration-guide-1.0.0.md
@@ -73,13 +73,7 @@ mv pages_ pages
 
 ```diff
 {
--  "plural-example": "This is singular because the value is {{count}}",
--  "plural-example_0": "Is zero because the value is {{count}}",
--  "plural-example_2": "Is two because the value is {{count}}",
--  "plural-example_plural": "Is in plural because the value is {{count}}"
-+  "plural-example_one": "This is singular because the value is {{count}}",
-+  "plural-example_zero": "Is zero because the value is {{count}}",
-+  "plural-example_two": "Is two because the value is {{count}}",
-+  "plural-example_many": "Is in plural because the value is {{count}}"
+-  "lorem-ipsum_plural": "The value is {{count}}"
++  "lorem-ipsum_other": "The value is {{count}}"
 }
 ```

--- a/docs/migration-guide-1.0.0.md
+++ b/docs/migration-guide-1.0.0.md
@@ -1,0 +1,85 @@
+# Migration Guide `0.x` to `1.0.0`
+
+This migration guide describes how to upgrade existing projects using `next-translate@0.x` to `next-translate@1.0.0`.
+
+1. Update `next-translate` to `^1.0.0`. If you're using a recent version of `npm` you can run this command:
+
+```bash
+npm install next-translate@^1.0.0
+```
+
+2. Update `next.config.js`:
+
+```diff
+-const { locales, defaultLocale } = require("./i18n.json");
++const nextTranslate = require("next-translate");
+
+module.exports = {
+-  i18n: { locales, defaultLocale },
++  ...nextTranslate(),
+};
+```
+
+3. Remove obsolete options from `i18n.json`:
+
+```diff
+{
+  "locales": ["de", "fr", "it"],
+  "defaultLocale": "de",
+-  "currentPagesDir": "pages_",
+-  "finalPagesDir": "pages",
+-  "localesPath": "locales",
+-  "package": false,
+  "pages": {
+    "*": ["common"],
+    "rgx:^/products": ["products"]
+  }
+}
+```
+
+4. Remove the extra build step in `package.json`:
+
+```diff
+"scripts": {
+-  "dev": "next-translate && next dev",
+-  "build": "next-translate && next build",
++  "dev": "next dev",
++  "build": "next build",
+  "start": "next start"
+}
+```
+
+5. Remove `/pages` from `.gitignore`:
+
+```diff
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+-# i18n
+-/pages
+```
+
+6. Rename directory `pages_` to `pages`:
+
+```bash
+rm -rf pages
+mv pages_ pages
+```
+
+7. Make sure to update plural suffixes. More information on this can be found [in the README](https://github.com/vinissimus/next-translate/tree/1.0.0-experimental#5-plurals).
+
+```diff
+{
+-  "plural-example": "This is singular because the value is {{count}}",
+-  "plural-example_0": "Is zero because the value is {{count}}",
+-  "plural-example_2": "Is two because the value is {{count}}",
+-  "plural-example_plural": "Is in plural because the value is {{count}}"
++  "plural-example_one": "This is singular because the value is {{count}}",
++  "plural-example_zero": "Is zero because the value is {{count}}",
++  "plural-example_two": "Is two because the value is {{count}}",
++  "plural-example_many": "Is in plural because the value is {{count}}"
+}
+```

--- a/docs/migration-guide-1.0.0.md
+++ b/docs/migration-guide-1.0.0.md
@@ -2,7 +2,11 @@
 
 This migration guide describes how to upgrade existing projects using `next-translate@0.x` to `next-translate@1.0.0`.
 
-1. Update `next-translate` to `^1.0.0`. If you're using a recent version of `npm` you can run this command:
+1. Update `next-translate` to `^1.0.0` using your preferred package manager.
+
+```bash
+yarn add next-translate@^1.0.0
+```
 
 ```bash
 npm install next-translate@^1.0.0


### PR DESCRIPTION
Add migration guide to  `/docs`, as discussed in #348.