### PR TITLE
Improve interface Translate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,22 @@
-import { ReactElement, ReactNode } from 'react'
-import nextTranslate from './plugin'
+import { ReactElement, ReactNode } from 'react';
+
+import nextTranslate from './plugin';
 
 export interface TranslationQuery {
   [name: string]: string | number
 }
 
 export interface Translate {
-  (
+  <T = string>(
     i18nKey: string | TemplateStringsArray,
     query: TranslationQuery | null | undefined,
     options: { returnObjects?: boolean; fallback?: string | string[] }
-  ): string | object
-  <R = string>(
+  ): T
+  (
     i18nKey: string | TemplateStringsArray,
     query: TranslationQuery | null | undefined
-  ): R
-  <R = string>(i18nKey: string | TemplateStringsArray): R
+  ): string
+  (i18nKey: string | TemplateStringsArray): string
 }
 
 export interface I18n {
@@ -82,8 +83,8 @@ export interface I18nDictionary {
 export interface DynamicNamespacesProps {
   dynamic?: (language: string, namespace: string) => Promise<I18nDictionary>
   namespaces?: string[]
-  fallback?: React.ReactNode
-  children?: React.ReactNode
+  fallback?: ReactNode
+  children?: ReactNode
 }
 
 module.exports = nextTranslate


### PR DESCRIPTION
The interface "Translate" describes the "translate" function in three variants.

In the following the variants of the return values of the function are considered.

1. the return value corresponds to a string or an object (of any complexity) - string | object

In the case of an object, the return type (string | object) requires a type cast from the function's user

Example 1
const translatedObject: TypeOfTranslatedObject = t(
translationKey,
    {},
    {returnObjects: true}
);

example 2
const translatedObject = t(
    translationKey,
    {},
    {returnObjects: true}
) as TypeOfTranslatedObject;

To make the use of the function more intuitive, the object type of the object to be translated is passed to the function call as generic type parameter.

Example 1 - Return of a simple object of the type TypeOfTranslatedObject

const translatedObject = t<TypeOfTranslatedObject>(
    translationKey,
    {},
    {returnObjects: true}
);

Example 2 - Return of an array whose contents correspond to the object type TypeOfTranslatedObject

const translatedObject = t<Array<TypeOfTranslatedObject>>(
    translationKey,
    {},
    {returnObjects: true}
);

The change made in the commit,
- introduces a generic type parameter and its initialization to a string,
- the type parameter is optional. If no type parameter is specified by the caller, the default value string is used.

The return value of the second and third variant corresponds to a string only and no other type.

The change made in the commit
- removes the generic type declaration, there is only one return type,
- an override from outside is not possible.