### PR TITLE
Add (getT) to get the t function outside components / pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Remember that `['dynamic']` namespace should **not** be listed on `pages` config
 
 Asynchronous function to load the `t` function outside components / pages. It works on both server-side and client-side.
 
-Unlike the useTranslation hook, we can use here any namespace, it doesn't have to be a namespace defined in the "pages" configuration. It downloads the namespace indicated as parameter on runtime.
+Unlike the useTranslation hook, we can use here any namespace, it doesn't have to be a namespace defined in the "pages" configuration. It downloads the namespace indicated as a parameter on runtime.
 
 Example inside `getStaticProps`:
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@
   - [withTranslation](#withtranslation)
   - [Trans Component](#trans-component)
   - [DynamicNamespaces](#dynamicnamespaces)
+  - [getT](#gett)
   - [I18nProvider](#i18nprovider)
   - [appWithI18n](#appwithi18n)
+  - [loadNamespaces](#loadnamespaces)
 - [5. Plurals](#5-plurals)
 - [6. Use HTML inside the translation](#6-use-html-inside-the-translation)
 - [7. Nested translations](#7-nested-translations)
@@ -367,6 +369,41 @@ Remember that `['dynamic']` namespace should **not** be listed on `pages` config
   - `fallback`- ReactNode - Fallback to display meanwhile the namespaces are loading. - **Optional**.
   - `dynamic` - function - By default it uses the [loadLocaleFrom](#3-configuration) in the configuration to load the namespaces, but you can specify another destination. - **Optional**.
 
+### getT
+
+**Size**: ~1.3kb 📦
+
+Asynchronous function to load the `t` function outside components / pages. It works on both server-side and client-side.
+
+Unlike the useTranslation hook, we can use here any namespace, it doesn't have to be a namespace defined in the "pages" configuration. It downloads the namespace indicated as parameter on runtime.
+
+Example inside `getStaticProps`:
+
+```js
+import getT from 'next-translate/getT'
+// ...
+export async function getStaticProps({ locale }) {
+  const t = await getT(locale, 'common')
+  const title = t('title')
+  return { props: { title } }
+}
+```
+
+Example inside API Route:
+
+```js
+import getT from 'next-translate/getT'
+
+export default async function handler(req, res) {
+  const t = await getT(req.query.__nextLocale, 'common')
+  const title = t('title')
+
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ title }))
+}
+```
+
 ### I18nProvider
 
 **Size**: ~3kb 📦
@@ -450,23 +487,16 @@ To load the namespaces, you must return in your pages the props that the helper 
 
 ```js
 import loadNamespaces from 'next-translate/loadNamespaces'
-import i18nConfig from '../i18n'
 
 export function getStaticProps({ locale }) {
-  const options = {
-    locale,
-    pathname: '/about',
-    ...i18nConfig,
-  }
-
   return {
     props: {
-      ...(await loadNamespaces(options)),
+      ...(await loadNamespaces({ locale, pathname: '/about' })),
     }
   }
 }
 ```
-To work well, it is necessary that your `_app.js` will be wrapped with the [appWithI18n](#appwithi18n).
+🚨 To work well, it is necessary that your `_app.js` will be wrapped with the [appWithI18n](#appwithi18n). Also, the `loadLocaleFrom` configuration property is **mandatory** to define it.
 
 ## 5. Plurals
 

--- a/examples/basic/pages/more-examples/dynamicroute/[slug].js
+++ b/examples/basic/pages/more-examples/dynamicroute/[slug].js
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import useTranslation from 'next-translate/useTranslation'
+import getT from 'next-translate/getT'
 import { useRouter } from 'next/router'
 
-export default function DynamicRoute() {
+export default function DynamicRoute({ title }) {
   const { query } = useRouter()
   const { t, lang } = useTranslation()
 
@@ -10,13 +11,19 @@ export default function DynamicRoute() {
 
   return (
     <>
-      <h1>{t`more-examples:dynamic-route`}</h1>
-      <h2>
+      <h1>{title}</h1>
+      <h2>{t`more-examples:dynamic-route`}</h2>
+      <h3>
         {query.slug} - {lang}
-      </h2>
+      </h3>
       <Link href="/">
         <a>{t`more-examples:go-to-home`}</a>
       </Link>
     </>
   )
+}
+
+export async function getServerSideProps({ locale }) {
+  const t = await getT(locale, 'common')
+  return { props: { title: t('title') } }
 }

--- a/examples/complex/src/pages/api/example.tsx
+++ b/examples/complex/src/pages/api/example.tsx
@@ -1,0 +1,11 @@
+import getT from 'next-translate/getT'
+
+// @ts-ignore
+export default async function handler(req, res) {
+  const t = await getT(req.query.__nextLocale, 'common')
+  const title = t('title')
+
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify({ title }))
+}

--- a/examples/complex/src/pages/more-examples/dynamicroute/[slug].tsx
+++ b/examples/complex/src/pages/more-examples/dynamicroute/[slug].tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
+import getT from 'next-translate/getT'
 import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
+import { GetStaticProps } from 'next'
 
-export default function DynamicRoute() {
+export default function DynamicRoute({ title = '' }) {
   const { query } = useRouter()
   const { t, lang } = useTranslation()
 
@@ -10,10 +12,11 @@ export default function DynamicRoute() {
 
   return (
     <>
-      <h1>{t`more-examples:dynamic-route`}</h1>
-      <h2>
+      <h1>{title}</h1>
+      <h2>{t`more-examples:dynamic-route`}</h2>
+      <h3>
         {query.slug} - {lang}
-      </h2>
+      </h3>
       <Link href="/">
         <a>{t`more-examples:go-to-home`}</a>
       </Link>
@@ -29,4 +32,9 @@ export function getStaticPaths({ locales }: any) {
     })),
     fallback: true,
   }
+}
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  const t = await getT(locale, 'common')
+  return { props: { title: t('title') } }
 }

--- a/examples/without-loader/pages/404.js
+++ b/examples/without-loader/pages/404.js
@@ -1,6 +1,5 @@
 import useTranslation from 'next-translate/useTranslation'
 import loadNamespaces from 'next-translate/loadNamespaces'
-import i18nConfig from '../i18n'
 
 export default function Error404() {
   const { t, lang } = useTranslation()
@@ -14,7 +13,6 @@ export default function Error404() {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/404',
     }),

--- a/examples/without-loader/pages/index.js
+++ b/examples/without-loader/pages/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import useTranslation from 'next-translate/useTranslation'
 import loadNamespaces from 'next-translate/loadNamespaces'
-import i18nConfig from '../i18n'
 import Header from '../components/header'
 
 export default function Home() {
@@ -24,7 +23,6 @@ export default function Home() {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/',
     }),

--- a/examples/without-loader/pages/more-examples/catchall/[...all].js
+++ b/examples/without-loader/pages/more-examples/catchall/[...all].js
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import useTranslation from 'next-translate/useTranslation'
 import loadNamespaces from 'next-translate/loadNamespaces'
 import { useRouter } from 'next/router'
-import i18nConfig from '../../../i18n'
 
 export default function All() {
   const { query } = useRouter()
@@ -46,7 +45,6 @@ export function getStaticPaths({ locales }) {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/more-examples/catchall/[..all]',
     }),

--- a/examples/without-loader/pages/more-examples/dynamic-namespace.js
+++ b/examples/without-loader/pages/more-examples/dynamic-namespace.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Trans from 'next-translate/Trans'
 import DynamicNamespaces from 'next-translate/DynamicNamespaces'
 import loadNamespaces from 'next-translate/loadNamespaces'
-import i18nConfig from '../../i18n'
 
 export default function ExampleWithDynamicNamespace() {
   return (
@@ -21,7 +20,6 @@ export default function ExampleWithDynamicNamespace() {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/more-examples/dynamic-namespace',
     }),

--- a/examples/without-loader/pages/more-examples/dynamicroute/[slug].js
+++ b/examples/without-loader/pages/more-examples/dynamicroute/[slug].js
@@ -2,7 +2,6 @@ import Link from 'next/link'
 import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import loadNamespaces from 'next-translate/loadNamespaces'
-import i18nConfig from '../../../i18n'
 
 export default function DynamicRoute() {
   const { query } = useRouter()
@@ -36,7 +35,6 @@ export function getStaticPaths({ locales }) {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/more-examples/dynamicroute/[slug]',
     }),

--- a/examples/without-loader/pages/more-examples/index.js
+++ b/examples/without-loader/pages/more-examples/index.js
@@ -6,7 +6,6 @@ import loadNamespaces from 'next-translate/loadNamespaces'
 import PluralExample from '../../components/plural-example'
 import Header from '../../components/header'
 import NoFunctionalComponent from '../../components/no-functional-component'
-import i18nConfig from '../../i18n'
 
 const Component = (props) => <p {...props} />
 
@@ -52,7 +51,6 @@ export default function MoreExamples() {
 export async function getStaticProps(ctx) {
   return {
     props: await loadNamespaces({
-      ...i18nConfig,
       ...ctx,
       pathname: '/more-examples',
     }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-translate",
-  "version": "1.0.0-canary.7",
+  "version": "1.0.0-canary.8",
   "description": "Tiny and powerful i18n tools (Next plugin + API) to translate your Next.js pages.",
   "license": "MIT",
   "keywords": [
@@ -36,6 +36,7 @@
     "appWithI18n*",
     "DynamicNamespaces*",
     "I18nProvider*",
+    "getT*",
     "loadNamespaces*",
     "Trans*",
     "withTranslation*",
@@ -45,7 +46,7 @@
   "scripts": {
     "build": "yarn clean && cross-env NODE_ENV=production && yarn tsc",
     "clean": "yarn clean:build && yarn clean:examples",
-    "clean:build": "rm -rf lib plugin appWith* Dynamic* I18n* index _context loadNa* Trans useT* withT* getP* *.d.ts types",
+    "clean:build": "rm -rf lib plugin appWith* Dynamic* I18n* index _context loadNa* Trans useT* withT* getP* *.d.ts getT transC* wrapT* types",
     "clean:examples": "rm -rf examples/**/.next && rm -rf examples/**/node_modules && rm -rf examples/**/yarn.lock",
     "example": "yarn example:complex",
     "example:basic": "yarn build && cd examples/basic && yarn && yarn dev",

--- a/src/DynamicNamespaces.tsx
+++ b/src/DynamicNamespaces.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react'
-import { DynamicNamespacesProps, I18nDictionary } from '.'
-import I18nProvider from './I18nProvider'
+import React, { useContext, useEffect, useState } from 'react'
+import { DynamicNamespacesProps, I18nDictionary, I18nConfig } from '.'
+import I18nProvider, { InternalContext } from './I18nProvider'
 import useTranslation from './useTranslation'
 
 export default function DynamicNamespaces({
@@ -9,7 +9,8 @@ export default function DynamicNamespaces({
   fallback,
   children,
 }: DynamicNamespacesProps): any {
-  const { lang, config = {} } = useTranslation()
+  const config = useContext(InternalContext).config as I18nConfig
+  const { lang } = useTranslation()
   const [loaded, setLoaded] = useState(false)
   const [pageNs, setPageNs] = useState<I18nDictionary[]>([])
   const loadLocale =

--- a/src/I18nProvider.tsx
+++ b/src/I18nProvider.tsx
@@ -1,142 +1,11 @@
 import React, { createContext, useContext } from 'react'
 import { useRouter } from 'next/router'
 import I18nContext from './_context'
+import transCore from './transCore'
 import useTranslation from './useTranslation'
-import {
-  I18n,
-  I18nConfig,
-  I18nProviderProps,
-  LoggerProps,
-  TranslationQuery,
-} from '.'
+import { I18n, I18nProviderProps } from '.'
 
-const NsContext = createContext({})
-
-/**
- * Get value from key (allow nested keys as parent.children)
- */
-function getDicValue(
-  dic: Object,
-  key: string = '',
-  options: { returnObjects?: boolean; fallback?: string | string[] } = {
-    returnObjects: false,
-  }
-): string | undefined | unknown {
-  const value: string | unknown = key
-    .split('.')
-    .reduce((val: Object, key: string) => {
-      if (typeof val === 'string') {
-        return {}
-      }
-
-      return val[key as keyof typeof val] || {}
-    }, dic)
-
-  if (
-    typeof value === 'string' ||
-    ((value as unknown) instanceof Object && options.returnObjects)
-  ) {
-    return value
-  }
-}
-
-/**
- * Control plural keys depending the {{count}} variable
- */
-function plural(
-  pluralRules,
-  dic: Object,
-  key: string,
-  query?: TranslationQuery | null
-): string {
-  if (!query || typeof query.count !== 'number') return key
-
-  const numKey = `${key}_${query.count}`
-  if (getDicValue(dic, numKey) !== undefined) return numKey
-
-  const pluralKey = `${key}_${pluralRules.select(query.count)}`
-  if (query.count > 1 && getDicValue(dic, pluralKey) !== undefined) {
-    return pluralKey
-  }
-
-  const nestedNumKey = `${key}.${query.count}`
-  if (getDicValue(dic, nestedNumKey) !== undefined) return nestedNumKey
-
-  const nestedKey = `${key}.${pluralRules.select(query.count)}`
-  if (getDicValue(dic, nestedKey) !== undefined) return nestedKey
-
-  return key
-}
-
-/**
- * Replace {{variables}} to query values
- */
-function interpolation({
-  text,
-  query,
-  config,
-}: {
-  text?: string
-  query?: TranslationQuery | null
-  config: I18nConfig
-}): string {
-  if (!text || !query) return text || ''
-
-  const escapeRegex = (str: string) =>
-    str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-  const {
-    interpolation: { prefix, suffix } = { prefix: '{{', suffix: '}}' },
-  } = config
-
-  return Object.keys(query).reduce((all, varKey) => {
-    const regex = new RegExp(
-      `${escapeRegex(prefix)}\\s*${varKey}\\s*${escapeRegex(suffix)}`,
-      'gm'
-    )
-    all = all.replace(regex, `${query[varKey]}`)
-    return all
-  }, text)
-}
-
-function objectInterpolation({
-  obj,
-  query,
-  config,
-}: {
-  obj: Record<string, string | unknown>
-  query?: TranslationQuery | null
-  config: I18nConfig
-}): Object {
-  if (!query || Object.keys(query).length === 0) return obj
-
-  Object.keys(obj).forEach((key) => {
-    if (obj[key] instanceof Object)
-      objectInterpolation({
-        obj: obj[key] as Record<string, string | unknown>,
-        query,
-        config,
-      })
-    if (typeof obj[key] === 'string')
-      obj[key] = interpolation({ text: obj[key] as string, query, config })
-  })
-
-  return obj
-}
-
-function missingKeyLogger({ namespace, i18nKey }: LoggerProps): void {
-  if (process.env.NODE_ENV === 'production') return
-
-  // This means that instead of "ns:value", "value" has been misspelled (without namespace)
-  if (!i18nKey) {
-    console.warn(
-      `[next-translate] The text "${namespace}" has no namespace in front of it.`
-    )
-    return
-  }
-  console.warn(
-    `[next-translate] "${namespace}:${i18nKey}" is missing in current namespace configuration. Try adding "${i18nKey}" to the namespace "${namespace}".`
-  )
-}
+export const InternalContext = createContext({ ns: {}, config: {} })
 
 export default function I18nProvider({
   lang: lng,
@@ -144,62 +13,23 @@ export default function I18nProvider({
   children,
   config: newConfig = {},
 }: I18nProviderProps) {
-  const { lang: parentLang, config: parentConfig = {} } = useTranslation()
+  const { lang: parentLang } = useTranslation()
   const { locale, defaultLocale } = useRouter() || {}
   const lang = lng || parentLang || locale || defaultLocale || ''
-  const ns = useContext(NsContext)
-  const allNamespaces = { ...ns, ...namespaces } as Record<string, Object>
+  const internal = useContext(InternalContext)
+  const allNamespaces = { ...internal.ns, ...namespaces } as Record<
+    string,
+    Object
+  >
   const pluralRules = new Intl.PluralRules(lang)
-  const config = { ...parentConfig, ...newConfig }
-  const { logger = missingKeyLogger } = config
-
-  function t(
-    key: string = '',
-    query: TranslationQuery | null | undefined,
-    options?: { returnObjects?: boolean; fallback?: string | string[] }
-  ) {
-    const k = Array.isArray(key) ? key[0] : key
-    const [namespace, i18nKey] = k.split(/:(.+)/)
-    const dic = allNamespaces[namespace] || {}
-    const keyWithPlural = plural(pluralRules, dic, i18nKey, query)
-    const value = getDicValue(dic, keyWithPlural, options)
-
-    const empty =
-      typeof value === 'undefined' ||
-      (typeof value === 'object' && !Object.keys(value).length)
-
-    const fallbacks =
-      typeof options?.fallback === 'string'
-        ? [options.fallback]
-        : options?.fallback || []
-
-    // Log only during CSR
-    if (typeof window !== 'undefined' && empty) {
-      logger({ namespace, i18nKey })
-    }
-
-    // Fallbacks
-    if (empty && Array.isArray(fallbacks) && fallbacks.length) {
-      const [firstFallback, ...restFallbacks] = fallbacks
-      if (typeof firstFallback === 'string') {
-        return t(firstFallback, query, { ...options, fallback: restFallbacks })
-      }
-    }
-
-    if (value instanceof Object) {
-      return objectInterpolation({
-        obj: value as Record<string, unknown>,
-        query,
-        config,
-      })
-    }
-
-    return interpolation({ text: value as string, query, config }) || k
-  }
+  const config = { ...internal.config, ...newConfig }
+  const t = transCore({ config, allNamespaces, pluralRules })
 
   return (
-    <I18nContext.Provider value={{ lang, t, config } as I18n}>
-      <NsContext.Provider value={allNamespaces}>{children}</NsContext.Provider>
+    <I18nContext.Provider value={{ lang, t } as I18n}>
+      <InternalContext.Provider value={{ ns: allNamespaces, config }}>
+        {children}
+      </InternalContext.Provider>
     </I18nContext.Provider>
   )
 }

--- a/src/appWithI18n.tsx
+++ b/src/appWithI18n.tsx
@@ -32,6 +32,8 @@ export default function appWithI18n(
     )
   }
 
+  globalThis.i18nConfig = config
+
   if (config.skipInitialProps) return AppWithTranslations
 
   AppWithTranslations.getInitialProps = async (appCtx: any) => {

--- a/src/getT.tsx
+++ b/src/getT.tsx
@@ -1,0 +1,14 @@
+import transCore from './transCore'
+import wrapTWithDefaultNs from './wrapTWithDefaultNs'
+
+export default async function getT(locale = '', namespace = '') {
+  const config = globalThis.i18nConfig
+  const defaultLoader = async (l, n) => Promise.resolve({})
+  const lang = locale || config.defaultLocale
+  const loader = config.loadLocaleFrom || defaultLoader
+  const allNamespaces = { [namespace]: await loader(lang, namespace) }
+  const pluralRules = new Intl.PluralRules(lang)
+  const t = transCore({ config, allNamespaces, pluralRules })
+
+  return wrapTWithDefaultNs(t, namespace)
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react'
 
-import nextTranslate from './plugin';
+import nextTranslate from './plugin'
 
 export interface TranslationQuery {
   [name: string]: string | number
@@ -22,7 +22,6 @@ export interface Translate {
 export interface I18n {
   t: Translate
   lang: string
-  config?: I18nConfig
 }
 
 export interface I18nProviderProps {

--- a/src/loadNamespaces.tsx
+++ b/src/loadNamespaces.tsx
@@ -2,36 +2,36 @@ import { LoaderConfig } from '.'
 import getPageNamespaces from './getPageNamespaces'
 
 export default async function loadNamespaces(config: LoaderConfig = {}) {
+  const conf = { ...globalThis.i18nConfig, ...config }
   const __lang: string =
-    config.locale || config.router?.locale || config.defaultLocale || ''
+    conf.locale || conf.router?.locale || conf.defaultLocale || ''
 
-  if (!config.pathname) {
+  if (!conf.pathname) {
     console.warn(
       '🚨 [next-translate] You forgot to pass the "pathname" inside "loadNamespaces" configuration'
     )
     return { __lang }
   }
 
-  if (!config.loaderName && config.loader !== false) {
+  if (!conf.loaderName && conf.loader !== false) {
     console.warn(
       '🚨 [next-translate] You can remove the "loadNamespaces" helper, unless you set "loader: false" in your i18n config file.'
     )
   }
 
-  const page =
-    removeTrailingSlash(config.pathname.replace(/\/index$/, '')) || '/'
-  const namespaces = await getPageNamespaces(config, page, config)
+  const page = removeTrailingSlash(conf.pathname.replace(/\/index$/, '')) || '/'
+  const namespaces = await getPageNamespaces(conf, page, conf)
   const defaultLoader = (l, n) => Promise.resolve({})
   const pageNamespaces =
     (await Promise.all(
       namespaces.map((ns) =>
-        typeof config.loadLocaleFrom === 'function'
-          ? config.loadLocaleFrom(__lang, ns)
+        typeof conf.loadLocaleFrom === 'function'
+          ? conf.loadLocaleFrom(__lang, ns)
           : defaultLoader(__lang, ns)
       )
     ).catch(() => {})) || []
 
-  if (config.logBuild !== false && typeof window === 'undefined') {
+  if (conf.logBuild !== false && typeof window === 'undefined') {
     const color = (c) => `\x1b[36m${c}\x1b[0m`
     console.log(
       color('next-translate'),
@@ -42,7 +42,7 @@ export default async function loadNamespaces(config: LoaderConfig = {}) {
       '- namespaces:',
       color(namespaces.join(', ')),
       '- used loader:',
-      color(config.loaderName || '-')
+      color(conf.loaderName || '-')
     )
   }
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -5,15 +5,6 @@ export default function nextTranslate(nextConfig: any = {}) {
   const path = require('path')
   const test = /\.(tsx|ts|js|mjs|jsx)$/
   const arePagesInsideSrc = fs.existsSync(path.join(process.cwd(), 'src/pages'))
-  let file = 'i18n.js'
-
-  if (!fs.existsSync(path.join(process.cwd(), file))) file = 'i18n.json'
-  if (!fs.existsSync(path.join(process.cwd(), file))) {
-    console.error(
-      '🚨 [next-translate] You should provide the next-translate config inside i18n.js / i18n.json root file.'
-    )
-    return nextConfig
-  }
 
   const i18n = nextConfig.i18n || {}
   const {
@@ -23,7 +14,7 @@ export default function nextTranslate(nextConfig: any = {}) {
     pages,
     logger,
     ...restI18n
-  } = require(path.join(process.cwd(), file))
+  } = require(path.join(process.cwd(), 'i18n'))
 
   // @todo Remove all these warnings on 1.1.0
   const migrationLink =

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -1,0 +1,173 @@
+import { I18nConfig, LoggerProps, TranslationQuery } from '.'
+
+export default function transCore({ config, allNamespaces, pluralRules }) {
+  const { logger = missingKeyLogger } = config
+
+  function t(key = '', query, options) {
+    const k = Array.isArray(key) ? key[0] : key
+    const [namespace, i18nKey] = k.split(/:(.+)/)
+    const dic = allNamespaces[namespace] || {}
+    const keyWithPlural = plural(pluralRules, dic, i18nKey, query)
+    const value = getDicValue(dic, keyWithPlural, options)
+
+    const empty =
+      typeof value === 'undefined' ||
+      (typeof value === 'object' && !Object.keys(value).length)
+
+    const fallbacks =
+      typeof options?.fallback === 'string'
+        ? [options.fallback]
+        : options?.fallback || []
+
+    // Log only during CSR
+    if (typeof window !== 'undefined' && empty) {
+      logger({ namespace, i18nKey })
+    }
+
+    // Fallbacks
+    if (empty && Array.isArray(fallbacks) && fallbacks.length) {
+      const [firstFallback, ...restFallbacks] = fallbacks
+      if (typeof firstFallback === 'string') {
+        return t(firstFallback, query, { ...options, fallback: restFallbacks })
+      }
+    }
+
+    if (value instanceof Object) {
+      return objectInterpolation({
+        obj: value as Record<string, unknown>,
+        query,
+        config,
+      })
+    }
+
+    return interpolation({ text: value as string, query, config }) || k
+  }
+
+  return t
+}
+
+/**
+ * Get value from key (allow nested keys as parent.children)
+ */
+function getDicValue(
+  dic: Object,
+  key: string = '',
+  options: { returnObjects?: boolean; fallback?: string | string[] } = {
+    returnObjects: false,
+  }
+): string | undefined | unknown {
+  const value: string | unknown = key
+    .split('.')
+    .reduce((val: Object, key: string) => {
+      if (typeof val === 'string') {
+        return {}
+      }
+
+      return val[key as keyof typeof val] || {}
+    }, dic)
+
+  if (
+    typeof value === 'string' ||
+    ((value as unknown) instanceof Object && options.returnObjects)
+  ) {
+    return value
+  }
+}
+
+/**
+ * Control plural keys depending the {{count}} variable
+ */
+function plural(
+  pluralRules,
+  dic: Object,
+  key: string,
+  query?: TranslationQuery | null
+): string {
+  if (!query || typeof query.count !== 'number') return key
+
+  const numKey = `${key}_${query.count}`
+  if (getDicValue(dic, numKey) !== undefined) return numKey
+
+  const pluralKey = `${key}_${pluralRules.select(query.count)}`
+  if (query.count > 1 && getDicValue(dic, pluralKey) !== undefined) {
+    return pluralKey
+  }
+
+  const nestedNumKey = `${key}.${query.count}`
+  if (getDicValue(dic, nestedNumKey) !== undefined) return nestedNumKey
+
+  const nestedKey = `${key}.${pluralRules.select(query.count)}`
+  if (getDicValue(dic, nestedKey) !== undefined) return nestedKey
+
+  return key
+}
+
+/**
+ * Replace {{variables}} to query values
+ */
+function interpolation({
+  text,
+  query,
+  config,
+}: {
+  text?: string
+  query?: TranslationQuery | null
+  config: I18nConfig
+}): string {
+  if (!text || !query) return text || ''
+
+  const escapeRegex = (str: string) =>
+    str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+  const {
+    interpolation: { prefix, suffix } = { prefix: '{{', suffix: '}}' },
+  } = config
+
+  return Object.keys(query).reduce((all, varKey) => {
+    const regex = new RegExp(
+      `${escapeRegex(prefix)}\\s*${varKey}\\s*${escapeRegex(suffix)}`,
+      'gm'
+    )
+    all = all.replace(regex, `${query[varKey]}`)
+    return all
+  }, text)
+}
+
+function objectInterpolation({
+  obj,
+  query,
+  config,
+}: {
+  obj: Record<string, string | unknown>
+  query?: TranslationQuery | null
+  config: I18nConfig
+}): any {
+  if (!query || Object.keys(query).length === 0) return obj
+
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] instanceof Object)
+      objectInterpolation({
+        obj: obj[key] as Record<string, string | unknown>,
+        query,
+        config,
+      })
+    if (typeof obj[key] === 'string')
+      obj[key] = interpolation({ text: obj[key] as string, query, config })
+  })
+
+  return obj
+}
+
+function missingKeyLogger({ namespace, i18nKey }: LoggerProps): void {
+  if (process.env.NODE_ENV === 'production') return
+
+  // This means that instead of "ns:value", "value" has been misspelled (without namespace)
+  if (!i18nKey) {
+    console.warn(
+      `[next-translate] The text "${namespace}" has no namespace in front of it.`
+    )
+    return
+  }
+  console.warn(
+    `[next-translate] "${namespace}:${i18nKey}" is missing in current namespace configuration. Try adding "${i18nKey}" to the namespace "${namespace}".`
+  )
+}

--- a/src/useTranslation.tsx
+++ b/src/useTranslation.tsx
@@ -1,18 +1,12 @@
 import { useContext } from 'react'
 import { I18n } from '.'
+import wrapTWithDefaultNs from './wrapTWithDefaultNs'
 import I18nContext from './_context'
 
 export default function useTranslation(defaultNs?: string) {
   const ctx = useContext(I18nContext)
-
-  if (typeof defaultNs !== 'string') return ctx
-
-  // Use default namespace if namespace is missing
-  function t(key = '', query, options) {
-    let k = Array.isArray(key) ? key[0] : key
-    if (!k.includes(':')) k = `${defaultNs}:${k}`
-    return ctx.t(k, query, options)
-  }
-
-  return { ...ctx, t } as I18n
+  return {
+    ...ctx,
+    t: wrapTWithDefaultNs(ctx.t, defaultNs),
+  } as I18n
 }

--- a/src/wrapTWithDefaultNs.tsx
+++ b/src/wrapTWithDefaultNs.tsx
@@ -1,0 +1,14 @@
+import { Translate } from '.'
+
+export default function wrapTWithDefaultNs(oldT: any, defaultNs?: string) {
+  if (typeof defaultNs !== 'string') return oldT
+
+  // Use default namespace if namespace is missing
+  function t(key = '', query, options): Translate {
+    let k = Array.isArray(key) ? key[0] : key
+    if (!k.includes(':')) k = `${defaultNs}:${k}`
+    return oldT(k, query, options)
+  }
+
+  return t
+}


### PR DESCRIPTION
Fixes https://github.com/vinissimus/next-translate/issues/382
Fixes https://github.com/vinissimus/next-translate/issues/329
Fixes https://github.com/vinissimus/next-translate/issues/341

# getT

**Size**: ~1.3kb 📦

Asynchronous function to load the `t` function outside components / pages. It works on both server-side and client-side.

Unlike the useTranslation hook, we can use here any namespace, it doesn't have to be a namespace defined in the "pages" configuration. It downloads the namespace indicated as a parameter on runtime.

Example inside `getStaticProps`:

```js
import getT from 'next-translate/getT'
// ...
export async function getStaticProps({ locale }) {
  const t = await getT(locale, 'common')
  const title = t('title')
  return { props: { title } }
}
```

Example inside API Route:

```js
import getT from 'next-translate/getT'

export default async function handler(req, res) {
  const t = await getT(req.query.__nextLocale, 'common')
  const title = t('title')

  res.statusCode = 200
  res.setHeader('Content-Type', 'application/json')
  res.end(JSON.stringify({ title }))
}
```