### PR TITLE
Add more information regarding listing all locales when using the i18n.js instead of i18n.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,9 @@ export default function ChangeLanguage() {
 }
 ```
 
-If you used the `i18n.js` config instead of the `i18n.json`, you can use the [Next.js useRouter hook](https://nextjs.org/docs/api-reference/next/router#userouter) to access the `locales` object and list all locales using the `Link` component.
+Another way of accessing the `locales` list to change the language is using the `Next.js router`. The `locales` list can be accessed using the [Next.js useRouter hook](https://nextjs.org/docs/api-reference/next/router#userouter).
+
+An example of a possible `ChangeLanguage` component using the `useRouter` hook from `Next.js`:
 
 ```js
 import { useRouter } from 'next/router';

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ import i18nConfig from '../i18n.json'
 
 const { locales } = i18nConfig
 
-function ChangeLanguage() {
+export default function ChangeLanguage() {
   const { t, lang } = useTranslation()
 
   return locales.map((lng) => {
@@ -704,6 +704,29 @@ function ChangeLanguage() {
       </Link>
     )
   })
+}
+```
+
+If you used the `i18n.js` config instead of the `i18n.json`, you can use the [Next.js useRouter hook](https://nextjs.org/docs/api-reference/next/router#userouter) to access the `locales` object and list all locales using the `Link` component.
+
+```js
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import useTranslation from 'next-translate/useTranslation';
+
+export default function ChangeLanguage() {
+  const { locales } = useRouter();
+  const { t, lang } = useTranslation()
+
+  return locales.map((lng) => {
+    if (lng === lang) return null;
+
+    return (
+      <Link href="/" locale={lng} key={lng}>
+        {t(`layout:language-name-${lng}`)}
+      </Link>
+    );
+  });
 }
 ```
 


### PR DESCRIPTION
Hi everyone,

I've started to use this library on a new project and I ended up using the `i18n.js` configuration file instead of the `i18n.json` one.

To be able to change the language, the `README` only has an example on how to access the locales list for the `i18n.json` and since with the `i18n.js` we need to use the `next.JS` router, I think it would be nice to add how to access the `locales` list using `next.JS` router to the documentation.

Hope it helps :)