### PR TITLE
Add default namespace param to withTranslation

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ class Description extends React.Component {
 export default withTranslation(NoFunctionalComponent)
 ```
 
+Similar to `useTranslation("common")` you can call `withTranslation` with the second parameter defining a default namespace to use:
+
+```
+export default withTranslation(NoFunctionalComponent, "common")
+```
+
 ### Trans Component
 
 **Size**: ~1.4kb 📦

--- a/__tests__/withTranslation.test.js
+++ b/__tests__/withTranslation.test.js
@@ -236,4 +236,20 @@ describe('withTranslation', () => {
       expect(container.textContent).toContain(expected)
     })
   })
+
+  test('should work with default namespace', () => {
+    const i18nKey = 'simple'
+    const namespace = {
+      simple: 'This is working',
+    }
+
+    const Inner = withTranslation(Translate, 'ns')
+
+    const { container } = render(
+      <I18nProvider lang="en" namespaces={{ ns: namespace }}>
+        <Inner i18nKey={i18nKey} />
+      </I18nProvider>
+    )
+    expect(container.textContent).toContain(namespace.simple)
+  })
 })

--- a/src/withTranslation.tsx
+++ b/src/withTranslation.tsx
@@ -6,10 +6,11 @@ import { NextComponentType } from 'next'
  * HOC to use the translations in no-functional components
  */
 export default function withTranslation<P = unknown>(
-  Component: React.ComponentType<P> | NextComponentType<any, any, any>
+  Component: React.ComponentType<P> | NextComponentType<any, any, any>,
+  defaultNs?: string
 ): React.ComponentType<Omit<P, 'i18n'>> {
   const WithTranslation: NextComponentType<any, any, any> = (props: P) => {
-    const i18n = useTranslation()
+    const i18n = useTranslation(defaultNs)
     return <Component {...props} i18n={i18n} />
   }
 


### PR DESCRIPTION
This PR adds the `defaultNs` parameter to the withTranslation HOC, mirroring the behavior of `useTranslation`:

```
export default withTranslation(NoFunctionalComponent, "common")
```

This improves user experience for similar usage with both methods and avoids duplicating the default namespace multiple time in the component. It is fully backwards compatible as the parameter is optional, equal to `useTranslation`.

* added optional parameter & pass through to internal useTranslation
* added test for parameter usage
* updated README