### PR TITLE
ts-fix: components object is not assignable to type ReactElement[]

### DIFF
--- a/src/Trans.tsx
+++ b/src/Trans.tsx
@@ -5,7 +5,7 @@ import React, {
   ReactElement,
   ReactNode,
 } from 'react'
-import { TransProps } from '.'
+import { TransComponentsObject, TransProps } from '.'
 import useTranslation from './useTranslation'
 
 const tagRe = /<(\w+)>(.*?)<\/\1>|<(\w+)\/>/
@@ -25,7 +25,7 @@ function getElements(
 
 function formatElements(
   value: string,
-  elements: ReactElement[] = []
+  elements: ReactElement[] | TransComponentsObject = []
 ): string | ReactNode[] {
   const parts = value.replace(nlRe, '').split(tagRe)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,10 @@ export interface TranslationQuery {
   [name: string]: string | number
 }
 
+export interface TransComponentsObject {
+  [key: string]: ReactElement
+}
+
 export interface Translate {
   <T = string>(
     i18nKey: string | TemplateStringsArray,
@@ -33,7 +37,7 @@ export interface I18nProviderProps {
 
 export interface TransProps {
   i18nKey: string
-  components?: ReactElement[]
+  components?: ReactElement[] | TransComponentsObject
   values?: TranslationQuery
   fallback?: string | string[]
 }


### PR DESCRIPTION
Typescript fix for [using components prop as a object](https://github.com/vinissimus/next-translate#trans-component).

![image](https://user-images.githubusercontent.com/41398445/105388134-584f3d00-5c27-11eb-8558-b98020b799ba.png)
