### PR TITLE
Allow empty translations

### DIFF
--- a/__tests__/useTranslation.test.js
+++ b/__tests__/useTranslation.test.js
@@ -782,5 +782,53 @@ describe('useTranslation', () => {
       )
       expect(container.textContent).toContain(expected)
     })
+
+    test('should work with empty interpolation result', () => {
+      const Inner = () => {
+        const { t } = useTranslation()
+        const text = t('ns:empty-interpolation', {
+          something: '',
+        })
+        return <>{text}</>
+      }
+
+      const expected = ''
+      const templateString = {
+        'empty-interpolation': '{{something}}',
+      }
+
+      const { container } = render(
+        <I18nProvider
+          lang="en"
+          namespaces={{ ns: templateString }}
+        >
+          <Inner />
+        </I18nProvider>
+      )
+      expect(container.textContent).toBe(expected)
+    })
+
+    test('should allow empty translations', () => {
+      const Inner = () => {
+        const { t } = useTranslation()
+        const text = t('ns:empty-translation.nested')
+        return <>{text}</>
+      }
+
+      const expected = ''
+      const templateString = {
+        'empty-translation': { 'nested': '' },
+      }
+
+      const { container } = render(
+        <I18nProvider
+          lang="en"
+          namespaces={{ ns: templateString }}
+        >
+          <Inner />
+        </I18nProvider>
+      )
+      expect(container.textContent).toBe(expected)
+    })
   })
 })

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -32,6 +32,11 @@ export default function transCore({ config, allNamespaces, pluralRules }) {
       }
     }
 
+    // no need to try interpolation
+    if (empty) {
+      return k
+    }
+
     if (value instanceof Object) {
       return objectInterpolation({
         obj: value as Record<string, unknown>,
@@ -40,7 +45,9 @@ export default function transCore({ config, allNamespaces, pluralRules }) {
       })
     }
 
-    return interpolation({ text: value as string, query, config }) || k
+    // this can return an empty string if either value was already empty
+    // or it contained only an interpolation (e.g. "{{name}}") and the query param was empty
+    return interpolation({ text: value as string, query, config })
   }
 
   return t
@@ -63,7 +70,10 @@ function getDicValue(
         return {}
       }
 
-      return val[key as keyof typeof val] || {}
+      const res = val[key as keyof typeof val]
+
+      // pass all truthy values or (empty) strings
+      return res || (typeof res === "string" ? res : {})
     }, dic)
 
   if (


### PR DESCRIPTION
This PR fixes #429 and allows an empty string to be returned 

a) if the translation was explicitly defined empty: `"i18nkey": ""`

b) if the translation only consists of an interpolation and the interpolation param was empty:
`"i18nkey": "{{name}}"` + `t("ns:i18nkey", {name: ""})`
