### PR TITLE
fix: setLanguage type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "Trans*",
     "withTranslation*",
     "useTranslation*",
-    "setLanguage",
+    "setLanguage*",
     "index*"
   ],
   "scripts": {


### PR DESCRIPTION
After the implementation of `setLanguage` thanks to this PR #496, I forgot to also include the declaration file `setLanguage.d.ts` on the npm package build. Excuse me for this mistake, I didn't know how the build system for this project work.

Could you double check if now everything is ok, so we can use `setLanguage`, if everything is good to go, we could release `1.0.4` a little bit faster, so we could finally use `setLanguage`, thanks! :smile: 

close #522