### PR TITLE
Fix: replace single qoutes with double qoutes in modifiedCode

### DIFF
--- a/src/plugin/templateWithHoc.ts
+++ b/src/plugin/templateWithHoc.ts
@@ -30,6 +30,11 @@ export default function templateWithHoc(
     )
   }
 
+  // Replace all single quotes with double qoutes so that
+  // template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // can replace tokenToReplace without issues
+  modifiedCode = modifiedCode.replace(/'/g, `"`)
+
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'
     import __appWithI18n from 'next-translate/appWithI18n'

--- a/src/plugin/templateWithLoader.ts
+++ b/src/plugin/templateWithLoader.ts
@@ -75,6 +75,11 @@ export default function templateWithLoader(
       })
   }
 
+  // Replace all single quotes with double qoutes so that
+  // template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // can replace tokenToReplace without issues
+  modifiedCode = modifiedCode.replace(/'/g, `"`)
+
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'
     import __loadNamespaces from 'next-translate/loadNamespaces'


### PR DESCRIPTION
Hey,

this fixes issue #395 

In monorepos (especially in Nx dev tools) when specifying custom path with `process.env.NEXT_TRANSLATE_PATH`, the error comes in:

![error](https://user-images.githubusercontent.com/13313058/102253924-44b60580-3f08-11eb-8427-eb47b47e7060.png)

As @creativej guessed in the issue, the error is indeed related to [templateWithHoc](https://github.com/vinissimus/next-translate/blob/master/src/plugin/templateWithHoc.ts)

The following line replaced modifiedCode wrongly:
```
template.replace(tokenToReplace, `\n${modifiedCode}\n`)
```

The problem is that `modifiedCode` contains single qoutes and exactly this caused the error on the screenshot. `template.replace(...)` eventually inserted modifiedCode in two different places inside `template`.

I just replaced single qoutes in modifiedCode with double qoutes. After that `template` is correctly replaced :)