### PR TITLE
replace quotes only for the special $' pattern specific to .replace()

### DIFF
--- a/__tests__/__snapshots__/templateWithHoc.test.js.snap
+++ b/__tests__/__snapshots__/templateWithHoc.test.js.snap
@@ -4,6 +4,11 @@ exports[`templateWithHoc exporting a arrow function with Hoc skipInitialProps: f
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import someHoc from \\"whatever\\";
 
 const __Page_Next_Translate__ = someHoc(() => {
@@ -23,6 +28,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc exporting a arrow function with Hoc skipInitialProps: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import someHoc from \\"whatever\\";
 
@@ -44,6 +54,11 @@ exports[`templateWithHoc exporting a arrow function with getInitialProps skipIni
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
@@ -64,6 +79,11 @@ exports[`templateWithHoc exporting a arrow function with getInitialProps skipIni
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
@@ -83,6 +103,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc exporting a class with a getInitialProps static | exporting apart skipInitialProps: false 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import React from \\"react\\";
 
@@ -112,6 +137,11 @@ exports[`templateWithHoc exporting a class with a getInitialProps static | expo
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -139,6 +169,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc exporting a class with a getInitialProps static outside + one commented before skipInitialProps: false 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import React from \\"react\\";
 
@@ -175,6 +210,11 @@ exports[`templateWithHoc exporting a class with a getInitialProps static outside
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 /*
@@ -210,6 +250,11 @@ exports[`templateWithHoc exporting a class with a getInitialProps static outside
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 const __Page_Next_Translate__ = class Page extends React.Component {
@@ -234,6 +279,11 @@ exports[`templateWithHoc exporting a class with a getInitialProps static outside
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 const __Page_Next_Translate__ = class Page extends React.Component {
@@ -257,6 +307,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc exporting a class with a getInitialProps static skipInitialProps: false 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import React from \\"react\\";
 
@@ -284,6 +339,11 @@ exports[`templateWithHoc exporting a class with a getInitialProps static skipIni
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 const __Page_Next_Translate__ = class Page extends React.Component {
@@ -310,6 +370,11 @@ exports[`templateWithHoc exporting a variable and with an existing HoC skipIniti
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import withWrapper from \\"somewhere\\";
 
 function Page() {
@@ -334,6 +399,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc exporting a variable and with an existing HoC skipInitialProps: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import withWrapper from \\"somewhere\\";
 
@@ -360,6 +430,11 @@ exports[`templateWithHoc page with multiple commented "export default" + the cor
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
@@ -383,6 +458,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc page with multiple commented "export default" + the correct one should do it right skipInitialProps: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 const Page = () => <div>Hello world</div>;
 
@@ -408,6 +488,11 @@ exports[`templateWithHoc page without "export default" should skip any transform
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
@@ -427,6 +512,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 exports[`templateWithHoc page without "export default" should skip any transformation skipInitialProps: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __appWithI18n from \\"next-translate/appWithI18n\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 const Page = () => <div>Hello world</div>;
 

--- a/__tests__/__snapshots__/templateWithLoader.test.js.snap
+++ b/__tests__/__snapshots__/templateWithLoader.test.js.snap
@@ -4,6 +4,10 @@ exports[`templateWithLoader exporting as a arrow function - without loader page:
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 export default () => <div>Hello world</div>;
 
 export async function getServerSideProps(ctx) {
@@ -29,6 +33,10 @@ exports[`templateWithLoader exporting as a arrow function - without loader page:
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 export default () => <div>Hello world</div>;
 
 export async function getStaticProps(ctx) {
@@ -53,6 +61,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader exporting as a class - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import React from \\"react\\";
 
@@ -93,6 +106,11 @@ exports[`templateWithLoader exporting as a class in a diferent line - without lo
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -128,6 +146,11 @@ exports[`templateWithLoader exporting as a class in a diferent line - without lo
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -162,6 +185,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader exporting as a function - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 export default function Page() {
   return <div>Hello world</div>;
@@ -202,6 +230,11 @@ exports[`templateWithLoader exporting as a function - without loader page: /blog
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 export default function Page() {
   return <div>Hello world</div>;
 }
@@ -229,6 +262,11 @@ exports[`templateWithLoader exporting as a function - without loader page: /inde
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 export default function Page() {
   return <div>Hello world</div>;
 }
@@ -255,6 +293,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader exporting as a function in diferent line - with loader page: /index | loader: getServerSideProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 function Page() {
   return <div>Hello world</div>;
@@ -293,6 +336,11 @@ exports[`templateWithLoader exporting as a function in diferent line - without l
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 function Page() {
   return <div>Hello world</div>;
 }
@@ -322,6 +370,11 @@ exports[`templateWithLoader exporting as a function in diferent line - without l
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 function Page() {
   return <div>Hello world</div>;
 }
@@ -350,6 +403,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader loader as a arrow function page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 export default function Page() {
   return <div>Hello world</div>;
@@ -383,6 +441,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader loader imported to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import _getStaticProps from \\"somewhere/getStaticProps\\";
 import getStaticPaths from \\"somewhere/getStaticPaths\\";
@@ -422,6 +485,11 @@ exports[`templateWithLoader loader with named import to another place + rename p
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import { getStaticPropsA as _getStaticProps } from \\"somewhere/getStaticProps\\";
 import { getStaticProps as getStaticPaths } from \\"somewhere/getStaticPaths\\";
 
@@ -460,6 +528,11 @@ exports[`templateWithLoader loader with named import to another place page: /ind
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
+
 import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
 import { getStaticPaths } from \\"somewhere/getStaticPaths\\";
 
@@ -497,6 +570,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader loader with one named import to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 import {
   getStaticPaths,
@@ -539,6 +617,10 @@ exports[`templateWithLoader should add the "as" on the import only when is neces
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
 
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
 import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
 
@@ -591,6 +673,11 @@ export async function getStaticProps(ctx) {
 exports[`templateWithLoader should remove exports of existings loaders with "as" page: /index | loader: getStaticProps | hasLoader: true 1`] = `
 "import __i18nConfig from \\"@next-translate-root/i18n\\";
 import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+
+(\\"$SomeString$\\");
+$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
+(\\".cssClass{content:' ';\\");
+('Hello \\"world\\"');
 
 export { anotherThing };
 

--- a/__tests__/templateWith.utils.js
+++ b/__tests__/templateWith.utils.js
@@ -1,0 +1,12 @@
+const specialPatternsOfReplaceMethod = ["$'", '$$', '$&', '$`']
+
+// take each pattern and create a string including the reversed version
+// i.e. $' => '$SomeString$'
+const specialPatternsCases = specialPatternsOfReplaceMethod.map(
+  (pattern) => `${pattern.split('').reverse().join('')}SomeString${pattern}`
+)
+const nestedQuotesCases = [`".cssClass{content:' ';"`, `'Hello "world"'`]
+
+export const specialStringsRenderer = specialPatternsCases
+  .concat(nestedQuotesCases)
+  .join('\n')

--- a/__tests__/templateWithHoc.test.js
+++ b/__tests__/templateWithHoc.test.js
@@ -1,4 +1,5 @@
 import templateWithHoc from '../src/plugin/templateWithHoc'
+import { specialStringsRenderer } from './templateWith.utils'
 import prettier from 'prettier'
 
 function clean(code) {
@@ -150,7 +151,10 @@ const tests = [
   `,
     cases: [{ skipInitialProps: false }, { skipInitialProps: true }],
   },
-]
+].map((t) => {
+  t.code = specialStringsRenderer + '\n' + t.code
+  return t
+})
 
 describe('templateWithHoc', () => {
   tests.forEach((d) => {

--- a/__tests__/templateWithLoader.test.js
+++ b/__tests__/templateWithLoader.test.js
@@ -1,4 +1,5 @@
 import templateWithLoader from '../src/plugin/templateWithLoader'
+import { specialStringsRenderer } from './templateWith.utils'
 import prettier from 'prettier'
 
 function clean(code) {
@@ -315,7 +316,10 @@ const tests = [
       },
     ],
   },
-]
+].map((t) => {
+  t.code = specialStringsRenderer + '\n' + t.code
+  return t
+})
 
 describe('templateWithLoader', () => {
   tests.forEach((d) => {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
       "<rootDir>/__tests__",
       "<rootDir>/src"
     ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      ".utils.js"
+    ],
     "transform": {
       "^.+\\.(j|t)sx?$": "babel-jest"
     }

--- a/src/plugin/templateWithHoc.ts
+++ b/src/plugin/templateWithHoc.ts
@@ -30,15 +30,6 @@ export default function templateWithHoc(
     )
   }
 
-  // Replace single quotes in '$something$' boundaries with double qoutes
-  // so that template.replace(tokenToReplace, `\n${modifiedCode}\n`)
-  // works without issues when going through special $' sequence.
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
-  // Originally issue is caused by '$RefreshHelpers$'
-  modifiedCode = modifiedCode.replace(/('\$).+(\$')/gi, (match) => {
-    return match.replace(/'/g, '"')
-  })
-
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'
     import __appWithI18n from 'next-translate/appWithI18n'
@@ -53,5 +44,9 @@ export default function templateWithHoc(
 
   if (typescript) template = template.replace(/\n/g, '\n// @ts-ignore\n')
 
-  return template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // Use callback to avoid parsing special patterns specific for .replace()
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+  return template.replace(tokenToReplace, () => {
+    return `\n${modifiedCode}\n`
+  })
 }

--- a/src/plugin/templateWithHoc.ts
+++ b/src/plugin/templateWithHoc.ts
@@ -30,10 +30,14 @@ export default function templateWithHoc(
     )
   }
 
-  // Replace all single quotes with double qoutes so that
-  // template.replace(tokenToReplace, `\n${modifiedCode}\n`)
-  // can replace tokenToReplace without issues
-  modifiedCode = modifiedCode.replace(/'/g, `"`)
+  // Replace single quotes in '$something$' boundaries with double qoutes
+  // so that template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // works without issues when going through special $' sequence.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+  // Originally issue is caused by '$RefreshHelpers$'
+  modifiedCode = modifiedCode.replace(/('\$).+(\$')/gi, (match) => {
+    return match.replace(/'/g, '"')
+  })
 
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'

--- a/src/plugin/templateWithLoader.ts
+++ b/src/plugin/templateWithLoader.ts
@@ -75,15 +75,6 @@ export default function templateWithLoader(
       })
   }
 
-  // Replace single quotes in '$something$' boundaries with double qoutes
-  // so that template.replace(tokenToReplace, `\n${modifiedCode}\n`)
-  // works without issues when going through special $' sequence.
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
-  // Originally issue is caused by '$RefreshHelpers$'
-  modifiedCode = modifiedCode.replace(/('\$).+(\$')/gi, (match) => {
-    return match.replace(/'/g, '"')
-  })
-
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'
     import __loadNamespaces from 'next-translate/loadNamespaces'
@@ -109,5 +100,9 @@ export default function templateWithLoader(
 
   if (typescript) template = template.replace(/\n/g, '\n// @ts-ignore\n')
 
-  return template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // Use callback to avoid parsing special patterns specific for .replace()
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+  return template.replace(tokenToReplace, () => {
+    return `\n${modifiedCode}\n`
+  })
 }

--- a/src/plugin/templateWithLoader.ts
+++ b/src/plugin/templateWithLoader.ts
@@ -75,10 +75,14 @@ export default function templateWithLoader(
       })
   }
 
-  // Replace all single quotes with double qoutes so that
-  // template.replace(tokenToReplace, `\n${modifiedCode}\n`)
-  // can replace tokenToReplace without issues
-  modifiedCode = modifiedCode.replace(/'/g, `"`)
+  // Replace single quotes in '$something$' boundaries with double qoutes
+  // so that template.replace(tokenToReplace, `\n${modifiedCode}\n`)
+  // works without issues when going through special $' sequence.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter
+  // Originally issue is caused by '$RefreshHelpers$'
+  modifiedCode = modifiedCode.replace(/('\$).+(\$')/gi, (match) => {
+    return match.replace(/'/g, '"')
+  })
 
   let template = `
     import __i18nConfig from '@next-translate-root/i18n'


### PR DESCRIPTION
Hey,

PR #527 fixed the error when developing in monorepos. At the same time it has introduced a new issue when replacing all qoutes in a string with double qoutes. This potentially leads to a situation where a nested "" qoutes pair appears inside another "" pair.

For example, usage with styled JSX fails the build:

![err-pic](https://user-images.githubusercontent.com/33040081/109225647-37e64580-77c6-11eb-991a-35b03a031c72.jpg)

Original issue was caused by `'$RefreshHelpers$'`. The problem was that  `'$RefreshHelpers$'` uses the `$'` sequence, which is one of the specials sequences for the `.replace()` method:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter

Instead of replacing all singular qoutes, it should be really targeted only at cases with special patterns for `.replace()`

I believe there is only `'$RefreshHelpers$'` that causes initial issue.

New regex in this PR matches only strings that follow pattern `'$anychar$'` in `modifiedCode`. Then it replaces singular qoutes with double qoutes in matched strings.