### PR TITLE
I18nDictionary type can accept more shapes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,7 +71,7 @@ export interface I18nLogger {
   (context: LoggerProps): void
 }
 
-interface Container<T> {
+export interface Container<T> {
   [index: number]: Container<T> | T
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,8 +71,12 @@ export interface I18nLogger {
   (context: LoggerProps): void
 }
 
+interface Container<T> {
+  [index: number]: Container<T> | T
+}
+
 export interface I18nDictionary {
-  [key: string]: string | I18nDictionary
+  [key: string]: string | I18nDictionary | Container<I18nDictionary | string>
 }
 
 export interface DynamicNamespacesProps {

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -1,4 +1,5 @@
 import {
+  Container,
   I18nConfig,
   I18nDictionary,
   LoaderConfig,
@@ -80,16 +81,35 @@ function getDicValue(
 ): string | undefined | object {
   const value: string | object = key
     .split('.')
-    .reduce((val: I18nDictionary | string, key: string) => {
-      if (typeof val === 'string') {
-        return {}
-      }
+    .reduce(
+      (
+        val: I18nDictionary | string | Container<I18nDictionary | string>,
+        key: string
+      ) => {
+        if (typeof val === 'string') {
+          return {}
+        }
 
-      const res = val[key as keyof typeof val]
+        /**
+         * Check if value is instance of container
+         */
+        const isContainer = <T,>(
+          val: string | I18nDictionary | Container<T>
+        ): val is Container<T> => {
+          return Array.isArray(val)
+        }
 
-      // pass all truthy values or (empty) strings
-      return res || (typeof res === 'string' ? res : {})
-    }, dic)
+        if (isContainer<I18nDictionary | string>(val)) {
+          return {}
+        }
+
+        const res = val[key as keyof typeof val]
+
+        // pass all truthy values or (empty) strings
+        return res || (typeof res === 'string' ? res : {})
+      },
+      dic
+    )
 
   if (
     typeof value === 'string' ||


### PR DESCRIPTION
This PR implements the requested feature from #521.
- The user can supply translation json files that accept a wider range of structures (e.g. nested arrays of strings)

What this PR does/changes:
- The I18nDictionary interface