### PR TITLE
Listen for `namespaces` changes and load necessary namespaces

### DIFF
--- a/src/DynamicNamespaces.tsx
+++ b/src/DynamicNamespaces.tsx
@@ -28,7 +28,7 @@ export default function DynamicNamespaces({
 
   useEffect(() => {
     loadNamespaces()
-  }, [])
+  }, [namespaces.join()])
 
   if (!loaded) return fallback || null
 


### PR DESCRIPTION
Hey,

We've wrapped our `App` in `DynamicNamespaces` to load the translation files for each page based on some props but when changing pages the translations are not always loaded. If I reload the page the translations appear. I noticed that the `useEffect` which loads the translations passes currently `[]` as the second argument but that means to never call this hook again even if namespaces have changed.

From [useEffect documentation](url):
> If you want to run an effect and clean it up only once (on mount and unmount), you can pass an empty array ([]) as a second argument. This tells React that your effect doesn’t depend on any values from props or state, so it never needs to re-run. This isn’t handled as a special case — it follows directly from how the dependencies array always works.