### PR TITLE
Remove console.warn because is already solved on Next.js 10.2.1-canary.4

### DIFF
--- a/src/plugin/loader.ts
+++ b/src/plugin/loader.ts
@@ -96,9 +96,6 @@ export default function loader(rawCode: string) {
     isGetStaticProps || isGetServerSideProps || isGetInitialProps
 
   if (isGetInitialProps || (!hasLoader && isWrapperWithExternalHOC)) {
-    console.warn(
-      `🚨 [next-translate] In Next 10.x.x there is an issue related to i18n and getInitialProps. We recommend to replace getInitialProps to getServerSideProps on ${page}. Issue: https://github.com/vercel/next.js/issues/18396`
-    )
     return templateWithHoc(rawCode, { typescript, hasLoadLocaleFrom })
   }
 


### PR DESCRIPTION
Already fixed in [Next.js canary 10.2.1-canary.4](https://github.com/vercel/next.js/releases/tag/v10.2.1-canary.4)