### PR TITLE
Add TransText component to allow Trans behaviour for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Sometimes we need to do some translations with HTML inside the text (bolds, link
 Example:
 
 ```jsx
-// The defined dictionary enter is like:
+// The defined dictionary entry is like:
 // "example": "<0>The number is <1>{{count}}</1></0>",
 <Trans
   i18nKey="common:example"
@@ -335,7 +335,7 @@ Example:
 Or using `components` prop as a object:
 
 ```jsx
-// The defined dictionary enter is like:
+// The defined dictionary entry is like:
 // "example": "<component>The number is <b>{{count}}</b></component>",
 <Trans
   i18nKey="common:example"
@@ -354,6 +354,30 @@ Or using `components` prop as a object:
   - `values` - Object - query params
   - `fallback` - string | string[] - Optional. Fallback i18nKey if the i18nKey doesn't match.
   - `defaultTrans` - string - Default translation for the key. If fallback keys are used, it will be used only after exhausting all the fallbacks.
+
+In cases where we require the functionality of the `Trans` component, but need a **string** to be interpolated, rather than the output of the `t(props.i18nKey)` function, there is also a `TransText` component, which takes a `text` prop instead of `i18nKey`.
+
+- **Props**:
+  - `text` - string - The string which (optionally) contains tags requiring interpolation
+  - `components` - Array | Object - This behaves exactly the same as `Trans` (see above).
+
+This is especially useful when mapping over the output of a `t()` with `returnObjects: true`:
+```jsx
+// The defined dictionary entry is like:
+// "content-list": ["List of <link>things</link>", "with <em>tags</em>"]
+const contentList = t('someNamespace:content-list', {}, { returnObjects: true });
+
+{contentList.map((listItem: string) => (
+  <TransText
+    text={listItem}
+    components={{
+      link: <a href="some-url" />,
+      em: <em />,
+    }}
+  />
+)}
+
+```
 
 ### DynamicNamespaces
 
@@ -575,7 +599,7 @@ or
 }
 ```
 
-> Intl.PluralRules API is **only available for modern browsers**, if you want to use it in legacy browsers you should add a [polyfill](https://github.com/eemeli/intl-pluralrules). 
+> Intl.PluralRules API is **only available for modern browsers**, if you want to use it in legacy browsers you should add a [polyfill](https://github.com/eemeli/intl-pluralrules).
 
 
 ## 6. Use HTML inside the translation
@@ -710,7 +734,7 @@ return {
   interpolation: {
     format: (value, format, lang) => {
       if(format === 'number') return formatters[lang].format(value)
-      return value 
+      return value
     }
   }
 }

--- a/__tests__/TransText.test.js
+++ b/__tests__/TransText.test.js
@@ -1,0 +1,127 @@
+import React from 'react'
+import { render, cleanup } from '@testing-library/react'
+
+import TransText from '../src/TransText'
+
+describe('TransText', () => {
+  afterEach(cleanup)
+
+  describe('without components', () => {
+    test('should return the provided text', () => {
+      const text = 'The number is 42'
+
+      const { container } = render(
+        <TransText text={text} />
+      )
+      expect(container.textContent).toContain(text)
+    })
+  })
+
+  describe('with components', () => {
+    test('should work with HTML5 Elements', () => {
+      const expectedText = 'The number is 42'
+      const text = '<0>The number is <1>42</1></0>'
+      const expectedHTML = '<h1 id="u1">The number is <b id="u2">42</b></h1>'
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={[<h1 id="u1" />, <b id="u2" />]}
+        />
+      )
+      expect(container.textContent).toContain(expectedText)
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+
+    test('should work with React Components', () => {
+      const text = '<0>The number is <1>42</1></0>'
+      const expectedText = 'The number is 42'
+      const expectedHTML = '<h1>The number is <b>42</b></h1>'
+      const H1 = (p) => <h1 {...p} />
+      const B = (p) => <b {...p} />
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={[<H1 />, <B />]}
+        />
+      )
+      expect(container.textContent).toContain(expectedText)
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+
+    test('should work with very nested components', () => {
+      const text = '<0><1>Is</1> <2>the <3>number</3></2> 42?</0>'
+      const expectedText = 'Is the number 42?'
+      const expectedHTML = '<div><p>Is</p> <b>the <i>number</i></b> 42?</div>'
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={[<div />, <p />, <b />, <i />]}
+        />
+      )
+      expect(container.textContent).toContain(expectedText)
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+
+    test('should work without replacing the HTMLElement if the index is incorrectly', () => {
+      const text = 'test <10>with bad index</10>.'
+      const expectedHTML = 'test with bad index.'
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={[<b />]}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+  })
+
+  describe('components prop as a object', () => {
+    test('should work with component as a object', () => {
+      const text = 'test <example>components as a object</example>.'
+      const expectedHTML = 'test <b>components as a object</b>.'
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={{ example: <b /> }}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+
+    test('should work with component as a object of React Components', () => {
+      const text = 'test <example>components as a object</example>.'
+      const expectedHTML = 'test <b class="test">components as a object</b>.'
+
+      const Component = ({ children }) => <b className="test">{children}</b>
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={{ example: <Component /> }}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+
+    test('should work with component as a object without replacing the HTMLElement if the key is incorrect', () => {
+      const text = 'test <example>components <thisIsIncorrect>as <u>a</u> object</thisIsIncorrect></example>.'
+      const expectedHTML =
+        'test <b class="test">components as <u>a</u> object</b>.'
+
+      const Component = ({ children }) => <b className="test">{children}</b>
+
+      const { container } = render(
+        <TransText
+          text={text}
+          components={{ example: <Component />, u: <u /> }}
+        />
+      )
+      expect(container.innerHTML).toContain(expectedHTML)
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "yarn clean && cross-env NODE_ENV=production && yarn tsc",
     "clean": "yarn clean:build && yarn clean:examples",
-    "clean:build": "rm -rf lib plugin appWith* Dynamic* I18n* index _context loadNa* setLang* Trans useT* withT* getP* getC* *.d.ts getT transC* wrapT* types",
+    "clean:build": "rm -rf lib plugin appWith* Dynamic* I18n* index _context loadNa* setLang* Trans* useT* withT* getP* getC* *.d.ts getT transC* wrapT* types formatElements",
     "clean:examples": "rm -rf examples/**/.next && rm -rf examples/**/node_modules && rm -rf examples/**/yarn.lock",
     "example": "yarn example:complex",
     "example:basic": "yarn build && cd examples/basic && yarn && yarn dev",

--- a/src/Trans.tsx
+++ b/src/Trans.tsx
@@ -1,62 +1,8 @@
-import React, {
-  cloneElement,
-  useMemo,
-  Fragment,
-  ReactElement,
-  ReactNode,
-} from 'react'
+import { useMemo } from 'react'
+
 import { TransProps } from '.'
 import useTranslation from './useTranslation'
-
-const tagRe = /<(\w+)>(.*?)<\/\1>|<(\w+)\/>/
-const nlRe = /(?:\r\n|\r|\n)/g
-
-function getElements(
-  parts: Array<string | undefined>
-): Array<string | undefined>[] {
-  if (!parts.length) return []
-
-  const [paired, children, unpaired, after] = parts.slice(0, 4)
-
-  return [
-    [(paired || unpaired) as string, children || ('' as string), after],
-  ].concat(getElements(parts.slice(4, parts.length)))
-}
-
-function formatElements(
-  value: string,
-  elements: ReactElement[] | Record<string, ReactElement> = []
-): string | ReactNode[] {
-  const parts = value.replace(nlRe, '').split(tagRe)
-
-  if (parts.length === 1) return value
-
-  const tree = []
-
-  const before = parts.shift()
-  if (before) tree.push(before)
-
-  getElements(parts).forEach(([key, children, after], realIndex: number) => {
-    const element =
-      // @ts-ignore
-      elements[key as string] || <Fragment />
-
-    tree.push(
-      cloneElement(
-        element,
-        { key: realIndex },
-
-        // format children for pair tags
-        // unpaired tags might have children if it's a component passed as a variable
-        children ? formatElements(children, elements) : element.props.children
-      )
-    )
-
-    if (after) tree.push(after)
-  })
-
-  return tree
-}
+import formatElements from './formatElements'
 
 /**
  * Translate transforming:
@@ -73,7 +19,7 @@ export default function Trans({
   const { t, lang } = useTranslation()
 
   /**
-   * Memorize the transformation
+   * Memoize the transformation
    */
   const result = useMemo(() => {
     const text = t(i18nKey, values, { fallback, default: defaultTrans })

--- a/src/TransText.ts
+++ b/src/TransText.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import formatElements from './formatElements';
+import { TransProps } from '.';
+
+type ValueTransProps = Omit<TransProps, 'i18nKey'> & {
+  text: string;
+}
+
+export default function TransText({
+  text,
+  components,
+}: ValueTransProps): any {
+  return useMemo(() => (!components || components.length === 0)
+    ? text
+    : formatElements(text, components), [text, components]) as string;
+}

--- a/src/TransText.ts
+++ b/src/TransText.ts
@@ -1,17 +1,18 @@
-import { useMemo } from 'react';
+import { useMemo } from 'react'
 
-import formatElements from './formatElements';
-import { TransProps } from '.';
+import formatElements from './formatElements'
+import { TransProps } from '.'
 
-type ValueTransProps = Omit<TransProps, 'i18nKey'> & {
-  text: string;
+type ValueTransProps = Pick<TransProps, 'components'> & {
+  text: string
 }
 
-export default function TransText({
-  text,
-  components,
-}: ValueTransProps): any {
-  return useMemo(() => (!components || components.length === 0)
-    ? text
-    : formatElements(text, components), [text, components]) as string;
+export default function TransText({ text, components }: ValueTransProps): any {
+  return useMemo(
+    () =>
+      !components || components.length === 0
+        ? text
+        : formatElements(text, components),
+    [text, components]
+  ) as string
 }

--- a/src/formatElements.tsx
+++ b/src/formatElements.tsx
@@ -1,0 +1,57 @@
+import {
+  cloneElement,
+  Fragment,
+  ReactElement,
+  ReactNode,
+} from 'react'
+
+const tagRe = /<(\w+)>(.*?)<\/\1>|<(\w+)\/>/
+const nlRe = /(?:\r\n|\r|\n)/g
+
+function getElements(
+  parts: Array<string | undefined>
+): Array<string | undefined>[] {
+  if (!parts.length) return []
+
+  const [paired, children, unpaired, after] = parts.slice(0, 4)
+
+  return [
+    [(paired || unpaired) as string, children || ('' as string), after],
+  ].concat(getElements(parts.slice(4, parts.length)))
+}
+
+
+export default function formatElements(
+  value: string,
+  elements: ReactElement[] | Record<string, ReactElement> = []
+): string | ReactNode[] {
+  const parts = value.replace(nlRe, '').split(tagRe)
+
+  if (parts.length === 1) return value
+
+  const tree = []
+
+  const before = parts.shift()
+  if (before) tree.push(before)
+
+  getElements(parts).forEach(([key, children, after], realIndex: number) => {
+    const element =
+      // @ts-ignore
+      elements[key as string] || <Fragment />
+
+    tree.push(
+      cloneElement(
+        element,
+        { key: realIndex },
+
+        // format children for pair tags
+        // unpaired tags might have children if it's a component passed as a variable
+        children ? formatElements(children, elements) : element.props.children
+      )
+    )
+
+    if (after) tree.push(after)
+  })
+
+  return tree
+}


### PR DESCRIPTION
Because `Trans` handles `useTranslation` internally, it means it cannot easily be used in conjunction with `returnObjects` when mapping over arrays of values containing components:

```
{
  "content-list": [
    "List of <0>things</0>",
    "with <1>variously</1> nested",
    "components and <2><1>content</1></2>!"
  ]
}
```

```
const contentList = t('someNamespace:content-list', {}, { returnObjects: true });
```

Rather than extending and overloading `Trans`, I am using a simple text-only version of it in a project locally, which I feel could be usefully added to the core package:

```
{contentList.map((listItem: string) => (
  <TransText
    text={listItem}
    components={[
      <a href="some-url" />,
      <b />,
      <em />,
    ]}
  />
)}
```

The functionality of `Trans` remains unchanged. I have hoisted `formatElements` into a separate file so it can be used by both `Trans` and `TransText`.