### PR TITLE
feat(697): allow to disable colors

### DIFF
--- a/src/loadNamespaces.tsx
+++ b/src/loadNamespaces.tsx
@@ -2,6 +2,12 @@ import { LoaderConfig, LocaleLoader } from '.'
 import getConfig from './getConfig'
 import getPageNamespaces from './getPageNamespaces'
 
+const colorEnabled =
+  process.env.NODE_DISABLE_COLORS == null &&
+  process.env.NO_COLOR == null &&
+  process.env.TERM !== 'dumb' &&
+  process.env.FORCE_COLOR !== '0'
+
 export default async function loadNamespaces(
   config: LoaderConfig = {}
 ): Promise<{
@@ -42,7 +48,7 @@ export default async function loadNamespaces(
     ).catch(() => {})) || []
 
   if (conf.logBuild !== false && typeof window === 'undefined') {
-    const color = (c: string) => `\x1b[36m${c}\x1b[0m`
+    const color = (c: string) => (colorEnabled ? `\x1b[36m${c}\x1b[0m` : c)
     console.log(
       color('next-translate'),
       `- compiled page:`,


### PR DESCRIPTION
Closes #697 

This PR allows to disable console log colors.

It changes the `color` function in `loadNamespaces` to avoid adding colors when they are disabled by using `NODE_DISABLE_COLORS`, `NO_COLOR`, `TERM=dumb` or `FORCE_COLOR=0`.

I did the less changes I could to the current code, but I was thinking about moving the color function to a util file to be able to test it. I haven't used destructuring for the `process.env` variables because the resulting code after the build was bigger.

I have tested it with the basic example in the repo and it's working as expected.

Let me know what you think.