### PR TITLE
Prevent infinite re-renders by memoizing the useTranslation hook

### DIFF
--- a/src/useTranslation.tsx
+++ b/src/useTranslation.tsx
@@ -1,12 +1,15 @@
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { I18n } from '.'
 import wrapTWithDefaultNs from './wrapTWithDefaultNs'
 import I18nContext from './_context'
 
-export default function useTranslation(defaultNS?: string): I18n {
+export default function useTranslation(defaultNs?: string): I18n {
   const ctx = useContext(I18nContext)
-  return {
-    ...ctx,
-    t: wrapTWithDefaultNs(ctx.t, defaultNS),
-  }
+  return useMemo(
+    () => ({
+      ...ctx,
+      t: wrapTWithDefaultNs(ctx.t, defaultNs),
+    }),
+    [ctx, defaultNs]
+  )
 }

--- a/src/useTranslation.tsx
+++ b/src/useTranslation.tsx
@@ -3,13 +3,13 @@ import { I18n } from '.'
 import wrapTWithDefaultNs from './wrapTWithDefaultNs'
 import I18nContext from './_context'
 
-export default function useTranslation(defaultNs?: string): I18n {
+export default function useTranslation(defaultNS?: string): I18n {
   const ctx = useContext(I18nContext)
   return useMemo(
     () => ({
       ...ctx,
-      t: wrapTWithDefaultNs(ctx.t, defaultNs),
+      t: wrapTWithDefaultNs(ctx.t, defaultNS),
     }),
-    [ctx, defaultNs]
+    [ctx, defaultNS]
   )
 }


### PR DESCRIPTION
This PR aims to prevent infinite re-renders when adding the `t` function in the `useEffect` dependency array.

```tsx
const { t } = useTranslation("ns");

useEffect(() => {
   // ...
}, [t]);
```

> A reproducible demo of the issue is available [on CodeSandbox](https://codesandbox.io/s/vibrant-waterfall-b4ymo?file=/pages/index.js).
> Remove the `t` function from the dependency array to stop it from re-rendering

The issue can be completely prevented by memoizing the return value of the `useTranslate` hook.

---

I see this was once added by #574, but got removed because of #604. I believe this needs to somehow be reintroduced in the library, to avoid being overriding eslint rules constantly.