### PR TITLE
fix: add revalidate to webpack loader

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -76,6 +76,7 @@ export default function nextTranslate(nextConfig: any = {}) {
           loader: 'next-translate/plugin/loader',
           options: {
             extensionsRgx: restI18n.extensionsRgx || test,
+            revalidate: restI18n.revalidate || 0,
             hasGetInitialPropsOnAppJs,
             hasAppJs: !!app,
             pagesPath: path.join(pagesPath, '/'),


### PR DESCRIPTION
missed during #757 

related with #754