### PR TITLE
This will fix lazy interpolation (Issue #781) 

### DIFF
--- a/__tests__/useTranslation.test.js
+++ b/__tests__/useTranslation.test.js
@@ -44,6 +44,28 @@ describe('useTranslation', () => {
       expect(container.textContent).toBe(expected)
     })
 
+    test('interpolation should not be lazy', () => {
+      const Inner = () => {
+        const { t } = useTranslation()
+        return t('common:key', {
+          something: 'something',
+          somethingElse: 'something else',
+        })
+      }
+
+      const expected = 'something else'
+
+      const { container } = render(
+        <I18nProvider
+          lang="en"
+          namespaces={{ common: { key: '{{somethingElse}}' } }}
+        >
+          <Inner />
+        </I18nProvider>
+      )
+      expect(container.textContent).toBe(expected)
+    })
+
     test('should return the key as fallback using wrong the nested translations', () => {
       const i18nKey = 'ns:grandfather.parent'
       const expected = 'ns:grandfather.parent'

--- a/src/transCore.tsx
+++ b/src/transCore.tsx
@@ -183,7 +183,7 @@ function interpolation({
   } = config.interpolation || {}
 
   const regexEnd =
-    suffix === '' ? '' : `\\s*,?\\s*([\\w-]+)?\\s*${escapeRegex(suffix)}`
+    suffix === '' ? '' : `(?:[\\s,]+([\\w-]*))?\\s*${escapeRegex(suffix)}`
   return Object.keys(query).reduce((all, varKey) => {
     const regex = new RegExp(
       `${escapeRegex(prefix)}\\s*${varKey}${regexEnd}`,


### PR DESCRIPTION
When passing data to the t function, variables whose names begin with the name of another variable will be replaced with the value of the shorter variable. See issue for details. 

This PR adds a test for this circumstance and fixes it.