### PR TITLE
fix loading of namespaces for missing files

### DIFF
--- a/__tests__/loadNamespaces.test.js
+++ b/__tests__/loadNamespaces.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import loadNamespaces from '../src/loadNamespaces'
+
+describe('loadNamespaces', () => {
+  test('should load a namespace', async () => {
+    const result = await loadNamespaces({
+      logBuild: false,
+      loader: false,
+      locale: 'en',
+      pages: { '*': ['common'] },
+      pathname: './index.js',
+      loadLocaleFrom: (__lang, ns) =>
+        Promise.resolve({ test: 'This is a Test' }),
+    })
+
+    expect(result).toEqual({
+      __lang: 'en',
+      __namespaces: { common: { test: 'This is a Test' } },
+    })
+  })
+
+  test('should load existing namespaces if one failed', async () => {
+    const result = await loadNamespaces({
+      logBuild: false,
+      loader: false,
+      locale: 'en',
+      pages: { '*': ['common', 'demo'] },
+      pathname: './index.js',
+      loadLocaleFrom: (__lang, ns) => {
+        if (ns === 'demo') {
+          return Promise.reject()
+        } else {
+          return Promise.resolve({ test: 'This is a Test' })
+        }
+      },
+    })
+
+    expect(result).toEqual({
+      __lang: 'en',
+      __namespaces: { common: { test: 'This is a Test' }, demo: {} },
+    })
+  })
+})

--- a/src/loadNamespaces.tsx
+++ b/src/loadNamespaces.tsx
@@ -1,7 +1,6 @@
 import { LoaderConfig, LocaleLoader } from '.'
 import getConfig from './getConfig'
 import getPageNamespaces from './getPageNamespaces'
-import { I18nDictionary } from '.'
 
 const colorEnabled =
   process.env.NODE_DISABLE_COLORS == null &&
@@ -44,20 +43,10 @@ export default async function loadNamespaces(
   const defaultLoader: LocaleLoader = () => Promise.resolve({})
   const pageNamespaces =
     (await Promise.all(
-      namespaces.map(
-        (ns) =>
-          new Promise<I18nDictionary>((resolve) => {
-            if (typeof conf.loadLocaleFrom === 'function') {
-              conf
-                .loadLocaleFrom(__lang, ns)
-                .then(resolve)
-                .catch(() => resolve({}))
-            } else {
-              defaultLoader(__lang, ns)
-                .then(resolve)
-                .catch(() => resolve({}))
-            }
-          })
+      namespaces.map((ns) =>
+        typeof conf.loadLocaleFrom === 'function'
+          ? conf.loadLocaleFrom(__lang, ns).catch(() => ({}))
+          : defaultLoader(__lang, ns)
       )
     )) || []
 


### PR DESCRIPTION
Currently if a translations file is missing no translation will be loaded. With this fix it will load all available namespaces and set translations to `{}` for missing files.