### PR TITLE
undo adding ctx.lang to dependency array of memorizing t in useTranslation

### DIFF
--- a/src/useTranslation.tsx
+++ b/src/useTranslation.tsx
@@ -10,6 +10,6 @@ export default function useTranslation(defaultNS?: string): I18n {
       ...ctx,
       t: wrapTWithDefaultNs(ctx.t, defaultNS),
     }),
-    [ctx.lang, defaultNS]
+    [ctx, defaultNS]
   )
 }


### PR DESCRIPTION
- this pr is to solve https://github.com/vinissimus/next-translate/issues/834 by undoing the commit https://github.com/vinissimus/next-translate/pull/829