### PR TITLE
Feature: use babel parser for plugin code transformations

### DIFF
--- a/__tests__/__snapshots__/templateWithHoc.test.js.snap
+++ b/__tests__/__snapshots__/templateWithHoc.test.js.snap
@@ -1,14 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`templateWithHoc exporting a arrow function with Hoc skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import someHoc from \\"whatever\\";
 
 const __Page_Next_Translate__ = someHoc(() => {
@@ -26,14 +20,8 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a arrow function with Hoc skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import someHoc from \\"whatever\\";
 
 const __Page_Next_Translate__ = someHoc(() => {
@@ -51,20 +39,14 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a arrow function with getInitialProps skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -76,20 +58,14 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a arrow function with getInitialProps skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -100,15 +76,9 @@ export default __appWithI18n(__Page_Next_Translate__, {
 "
 `;
 
-exports[`templateWithHoc exporting a class with a getInitialProps static | exporting apart skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithHoc exporting a class with a getInitialProps static | exporting apart skipInitialProps: false 1`] = `
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -122,7 +92,6 @@ class Page extends React.Component {
 }
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -133,15 +102,9 @@ export default __appWithI18n(__Page_Next_Translate__, {
 "
 `;
 
-exports[`templateWithHoc exporting a class with a getInitialProps static | exporting apart skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithHoc exporting a class with a getInitialProps static | exporting apart skipInitialProps: true 1`] = `
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -155,7 +118,6 @@ class Page extends React.Component {
 }
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -167,36 +129,30 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static outside + one commented before skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
-
 /*
-    const __Page_Next_Translate__ = class FakePage extends React.Component {
-      render() {
-        return <div>Hello world</div>
-      }
-    } */
+export default class FakePage extends React.Component {
+  render() {
+    return <div>Hello world</div>
+  }
+} */
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
 // FakePage.getInitialProps = () => ({})
-/* 
-     __Page_Next_Translate__.getInitialProps = () => ({})
-    */
-__Page_Next_Translate__.getInitialProps = () => ({});
 
-export default __appWithI18n(__Page_Next_Translate__, {
+/* 
+  Page.getInitialProps = () => ({})
+*/
+Page.getInitialProps = () => ({});
+
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: false,
@@ -207,36 +163,30 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static outside + one commented before skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
-
 /*
-    const __Page_Next_Translate__ = class FakePage extends React.Component {
-      render() {
-        return <div>Hello world</div>
-      }
-    } */
+export default class FakePage extends React.Component {
+  render() {
+    return <div>Hello world</div>
+  }
+} */
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
 // FakePage.getInitialProps = () => ({})
-/* 
-     __Page_Next_Translate__.getInitialProps = () => ({})
-    */
-__Page_Next_Translate__.getInitialProps = () => ({});
 
-export default __appWithI18n(__Page_Next_Translate__, {
+/* 
+  Page.getInitialProps = () => ({})
+*/
+Page.getInitialProps = () => ({});
+
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: true,
@@ -247,25 +197,19 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static outside skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
-__Page_Next_Translate__.getInitialProps = () => ({});
+Page.getInitialProps = () => ({});
 
-export default __appWithI18n(__Page_Next_Translate__, {
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: false,
@@ -276,25 +220,19 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static outside skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
-__Page_Next_Translate__.getInitialProps = () => ({});
+Page.getInitialProps = () => ({});
 
-export default __appWithI18n(__Page_Next_Translate__, {
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: true,
@@ -305,17 +243,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   static getInitialProps() {
     return {};
   }
@@ -323,9 +255,9 @@ const __Page_Next_Translate__ = class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
-export default __appWithI18n(__Page_Next_Translate__, {
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: false,
@@ -336,17 +268,11 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a class with a getInitialProps static skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
-const __Page_Next_Translate__ = class Page extends React.Component {
+class Page extends React.Component {
   static getInitialProps() {
     return {};
   }
@@ -354,9 +280,9 @@ const __Page_Next_Translate__ = class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
-};
+}
 
-export default __appWithI18n(__Page_Next_Translate__, {
+export default __appWithI18n(Page, {
   ...__i18nConfig,
   isLoader: true,
   skipInitialProps: true,
@@ -367,14 +293,8 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a variable and with an existing HoC skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import withWrapper from \\"somewhere\\";
 
 function Page() {
@@ -383,9 +303,7 @@ function Page() {
 
 const anothervariable = withWrapper(Page);
 const somevariable = anothervariable;
-
 const __Page_Next_Translate__ = somevariable;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -397,14 +315,8 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc exporting a variable and with an existing HoC skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import withWrapper from \\"somewhere\\";
 
 function Page() {
@@ -413,9 +325,7 @@ function Page() {
 
 const anothervariable = withWrapper(Page);
 const somevariable = anothervariable;
-
 const __Page_Next_Translate__ = somevariable;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -427,24 +337,18 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc page with multiple commented "export default" + the correct one should do it right skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
-Page.getInitialProps = () => ({});
+Page.getInitialProps = () => ({}); // export default Page
 
-// const __Page_Next_Translate__ = Page
 /*
-      const __Page_Next_Translate__ = Page
-    */
-const __Page_Next_Translate__ = Page;
+  export default Page
+*/
 
+const __Page_Next_Translate__ = Page;
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -456,24 +360,18 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc page with multiple commented "export default" + the correct one should do it right skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
-Page.getInitialProps = () => ({});
+Page.getInitialProps = () => ({}); // export default Page
 
-// const __Page_Next_Translate__ = Page
 /*
-      const __Page_Next_Translate__ = Page
-    */
-const __Page_Next_Translate__ = Page;
+  export default Page
+*/
 
+const __Page_Next_Translate__ = Page;
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -485,20 +383,14 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc page without "export default" should skip any transformation skipInitialProps: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,
@@ -510,20 +402,14 @@ export default __appWithI18n(__Page_Next_Translate__, {
 `;
 
 exports[`templateWithHoc page without "export default" should skip any transformation skipInitialProps: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __appWithI18n from \\"next-translate/appWithI18n\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+"import __appWithI18n from \\"next-translate/appWithI18n\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 const Page = () => <div>Hello world</div>;
 
 Page.getInitialProps = () => ({});
 
 const __Page_Next_Translate__ = Page;
-
 export default __appWithI18n(__Page_Next_Translate__, {
   ...__i18nConfig,
   isLoader: true,

--- a/__tests__/__snapshots__/templateWithLoader.test.js.snap
+++ b/__tests__/__snapshots__/templateWithLoader.test.js.snap
@@ -1,116 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`templateWithLoader exporting as a arrow function - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader exporting as a arrow function - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default () => <div>Hello world</div>;
 
-export async function getServerSideProps(ctx) {
+async function __next_translate_getServerSideProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/blog/[post]/[...catchall]\\",
-        loaderName: \\"getServerSideProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/blog/[post]/[...catchall]\\",
+      loaderName: \\"getServerSideProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getServerSideProps as getServerSideProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a arrow function - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader exporting as a arrow function - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default () => <div>Hello world</div>;
 
-export async function getStaticProps(ctx) {
+async function __next_translate_getStaticProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a class - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a class - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
-
 export default class Page extends React.Component {
   render() {
     return <div>Hello world</div>;
   }
 }
 
-function _getStaticProps() {
-  return { props: {} };
-}
-
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+function getStaticProps() {
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: {},
   };
 }
+
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
+  return {
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
+  };
+}
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a class in a diferent line - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a class in a diferent line - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -120,37 +94,28 @@ class Page extends React.Component {
 }
 
 const myPage = Page;
-
 export default myPage;
 
-export async function getServerSideProps(ctx) {
+async function __next_translate_getServerSideProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/blog/[post]/[...catchall]\\",
-        loaderName: \\"getServerSideProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/blog/[post]/[...catchall]\\",
+      loaderName: \\"getServerSideProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getServerSideProps as getServerSideProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a class in a diferent line - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a class in a diferent line - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import React from \\"react\\";
 
 class Page extends React.Component {
@@ -160,186 +125,152 @@ class Page extends React.Component {
 }
 
 const myPage = Page;
-
 export default myPage;
 
-export async function getStaticProps(ctx) {
+async function __next_translate_getStaticProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a function - with loader page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
-
 export function getStaticPaths() {
   return {};
 }
 
-function _getStaticProps() {
-  return { props: {} };
-}
-
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+function getStaticProps() {
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: {},
   };
 }
+
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
+  return {
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
+  };
+}
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a function - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
 
-export async function getServerSideProps(ctx) {
+async function __next_translate_getServerSideProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/blog/[post]/[...catchall]\\",
-        loaderName: \\"getServerSideProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/blog/[post]/[...catchall]\\",
+      loaderName: \\"getServerSideProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getServerSideProps as getServerSideProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader exporting as a function - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
 
-export async function getStaticProps(ctx) {
+async function __next_translate_getStaticProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function in diferent line - with loader page: /index | loader: getServerSideProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader exporting as a function in diferent line - with loader page: /index | loader: getServerSideProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 function Page() {
   return <div>Hello world</div>;
 }
 
-function _getServerSideProps() {
-  return { props: {} };
+function getServerSideProps() {
+  return {
+    props: {},
+  };
 }
 
 export default Page;
 
-export async function getServerSideProps(ctx) {
-  let res = _getServerSideProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getServerSideProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getServerSideProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getServerSideProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getServerSideProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getServerSideProps as getServerSideProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function in diferent line - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader exporting as a function in diferent line - without loader page: /blog/[post]/[...catchall] | loader: getServerSideProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 function Page() {
   return <div>Hello world</div>;
@@ -347,33 +278,26 @@ function Page() {
 
 export default Page;
 
-export async function getServerSideProps(ctx) {
+async function __next_translate_getServerSideProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/blog/[post]/[...catchall]\\",
-        loaderName: \\"getServerSideProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/blog/[post]/[...catchall]\\",
+      loaderName: \\"getServerSideProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getServerSideProps as getServerSideProps };
 "
 `;
 
-exports[`templateWithLoader exporting as a function in diferent line - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader exporting as a function in diferent line - without loader page: /index | loader: getStaticProps | hasLoader: false 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
 function Page() {
   return <div>Hello world</div>;
@@ -381,562 +305,446 @@ function Page() {
 
 export default Page;
 
-export async function getStaticProps(ctx) {
+async function __next_translate_getStaticProps(ctx) {
   return {
-    props: {
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader as a arrow function page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader loader as a arrow function page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
 
-const _getStaticProps = () => ({ props: {} });
+const getStaticProps = () => ({
+  props: {},
+});
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader as a wrapper page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader loader as a wrapper page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
+const getStaticProps = wrapper.getStaticProps(() => ({
+  props: {},
+}));
 
-const _getStaticProps = wrapper.getStaticProps(() => ({ props: {} }));
-
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader imported to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
-import _getStaticProps from \\"somewhere/getStaticProps\\";
+exports[`templateWithLoader loader imported to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
+import getStaticProps from \\"somewhere/getStaticProps\\";
 import getStaticPaths from \\"somewhere/getStaticPaths\\";
-
 const config = {};
-
 export default function Page() {
   return <div>Hello world</div>;
 }
-
 export { config, getStaticPaths };
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader with named import to another place + rename page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
-import { getStaticPropsA as _getStaticProps } from \\"somewhere/getStaticProps\\";
+exports[`templateWithLoader loader with named import to another place + rename page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
+import { getStaticPropsA as getStaticProps } from \\"somewhere/getStaticProps\\";
 import { getStaticProps as getStaticPaths } from \\"somewhere/getStaticPaths\\";
-
 const config = {};
-
 export default function Page() {
   return <div>Hello world</div>;
 }
-
 export { config, getStaticPaths };
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader with named import to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
-import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
+exports[`templateWithLoader loader with named import to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
+import { getStaticProps } from \\"somewhere/getStaticProps\\";
 import { getStaticPaths } from \\"somewhere/getStaticPaths\\";
-
 const config = {};
-
 export default function Page() {
   return <div>Hello world</div>;
 }
-
 export { config, getStaticPaths };
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader loader with one named import to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader loader with one named import to another place page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import {
   getStaticPaths,
-  getStaticProps as _getStaticProps,
+  getStaticProps,
   config,
 } from \\"somewhere/getStaticProps\\";
-
 export default function Page() {
   const test = \\"getStaticProps\\";
   console.log(\\"This should log getStaticProps without any modification\\");
   return <div>Hello getStaticProps</div>;
 }
-
 export { config, getStaticPaths };
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should add "revalidate: 55" prop into getStaticProps page: /index | loader: getStaticProps | hasLoader: true | revalidate: 55 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+exports[`templateWithLoader should add "revalidate: 55" prop into getStaticProps page: /index | loader: getStaticProps | hasLoader: true | revalidate: 55 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
 function Page() {
   return <div>Hello world</div>;
 }
 
 export default Page;
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
   return {
     revalidate: 55,
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should add the "as" on the import only when is necessary page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
-import { getStaticProps as _getStaticProps } from \\"somewhere/getStaticProps\\";
-
-import {
-  getStaticPropsA,
-  getStaticProps as _getStaticProps,
-  getStaticPropsB,
-} from \\"somewhere/getStaticProps\\";
+exports[`templateWithLoader should add the "as" on the import only when is necessary page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import { getStaticProps as getStaticPaths } from \\"somewhere/getStaticPaths\\";
 import { fake_getStaticProps } from \\"somewhere/getStaticPaths\\";
-
 import {
   getStaticPropsA,
-  getStaticProps as _getStaticProps,
+  getStaticProps,
   getStaticPropsB,
-} from \\"somewhere/getStaticProps\\";
+} from \\"somewhere/getStaticProps\\"; // Comment to import getStaticProps
 
-import {
-  getStaticPropsA,
-  getStaticProps as _getStaticProps,
-  getStaticPropsB,
-} from \\"somewhere/getStaticProps\\";
-let _getStaticProps = false;
-// Comment to import getStaticProps
 const a = \\"import { getStaticProps }\\";
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should allow developers to override revalidate prop per page, by having the "default" revalidate defined before "...res" page: /index | loader: getStaticProps | hasLoader: true | revalidate: 88 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
+exports[`templateWithLoader should allow developers to override revalidate prop per page, by having the "default" revalidate defined before "...res" page: /index | loader: getStaticProps | hasLoader: true | revalidate: 88 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 export default function Page() {
   return <div>Hello world</div>;
 }
 
-function _getStaticProps() {
-  return { revalidate: 10, props: { prop1: \\"hello\\" } };
+function getStaticProps() {
+  return {
+    revalidate: 10,
+    props: {
+      prop1: \\"hello\\",
+    },
+  };
 }
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
     revalidate: 88,
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should not add "revalidate" prop into getStaticProps because revalidate < 0 page: /index | loader: getStaticProps | hasLoader: true | revalidate: -1 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+exports[`templateWithLoader should not add "revalidate" prop into getStaticProps because revalidate < 0 page: /index | loader: getStaticProps | hasLoader: true | revalidate: -1 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
 function Page() {
   return <div>Hello world</div>;
 }
 
 export default Page;
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should not add "revalidate" prop into getStaticProps because revalidate = 0 page: /index | loader: getStaticProps | hasLoader: true | revalidate: 0 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+exports[`templateWithLoader should not add "revalidate" prop into getStaticProps because revalidate = 0 page: /index | loader: getStaticProps | hasLoader: true | revalidate: 0 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
 function Page() {
   return <div>Hello world</div>;
 }
 
 export default Page;
 
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    props: await __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should remove exports of existings loaders with "as" page: /index | loader: getStaticProps | hasLoader: true 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader should remove exports of existings loaders with "as" page: /index | loader: getStaticProps | hasLoader: true 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
+const test = 0,
+  anotherThing = 0,
+  something = 0,
+  getStaticPropsA = 0,
+  getStaticPropsB = 0;
+export { test as getStaticProps1 };
 export { anotherThing };
+export { something, getStaticPropsA as getStaticProps2 };
+export { getStaticPropsB };
 
-export { something };
-export { something };
-export { something, getStaticPropsB };
-
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    test(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
   return {
-    ...res,
-    props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
-    },
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
   };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;
 
-exports[`templateWithLoader should use the revalidate value already present on getStaticProps arrow function page: /index | loader: getStaticProps | hasLoader: true | revalidate: 77 1`] = `
-"import __i18nConfig from \\"@next-translate-root/i18n\\";
-import __loadNamespaces from \\"next-translate/loadNamespaces\\";
-
-(\\"$SomeString$\\");
-$$SomeString$$ & $SomeString$ & \`$SomeString$\`;
-(\\".cssClass{content:' ';\\");
-('Hello \\"world\\"');
-
+exports[`templateWithLoader should use the revalidate value already present on getStaticProps arrow function page: /index | loader: getStaticProps | hasLoader: true | revalidate: 77 1`] = `
+"import __loadNamespaces from \\"next-translate/loadNamespaces\\";
+import __i18nConfig from \\"@next-translate-root/i18n\\";
 import { GetStaticProps } from \\"next\\";
-
 export default function Page() {
   return <div>Hello world</div>;
 }
 
-const _getStaticProps: GetStaticProps = () => {
-  return { revalidate: 10, props: { prop1: \\"hello\\" } };
-};
-
-export async function getStaticProps(ctx) {
-  let res = _getStaticProps(ctx);
-  if (typeof res.then === \\"function\\") res = await res;
+const getStaticProps: GetStaticProps = () => {
   return {
-    revalidate: 77,
-    ...res,
+    revalidate: 10,
     props: {
-      ...(res.props || {}),
-      ...(await __loadNamespaces({
-        ...ctx,
-        pathname: \\"/index\\",
-        loaderName: \\"getStaticProps\\",
-        ...__i18nConfig,
-        loadLocaleFrom: (l, n) =>
-          import(\`@next-translate-root/locales/\${l}/\${n}\`).then(
-            (m) => m.default
-          ),
-      })),
+      prop1: \\"hello\\",
     },
   };
+};
+
+async function __next_translate_getStaticProps(ctx) {
+  const [userLoaderResult, namespaceProps] = await Promise.all([
+    getStaticProps(ctx),
+    __loadNamespaces({
+      ...ctx,
+      pathname: \\"/index\\",
+      loaderName: \\"getStaticProps\\",
+      ...__i18nConfig,
+      loadLocaleFrom: (l, n) =>
+        import(\`@next-translate-root/locales/\${l}/\${n}\`).then((m) => m.default),
+    }),
+  ]);
+  return {
+    revalidate: 77,
+    ...userLoaderResult,
+    props: { ...userLoaderResult.props, ...namespaceProps },
+  };
 }
+
+export { __next_translate_getStaticProps as getStaticProps };
 "
 `;

--- a/__tests__/ast.test.js
+++ b/__tests__/ast.test.js
@@ -1,0 +1,26 @@
+import generate from '@babel/generator'
+import * as babelParser from '@babel/parser'
+import { identifier } from '@babel/types'
+import { removeNamedExport } from '../src/plugin/ast'
+import removeNamedExportTestCases from './removeNamedExport.testCases'
+import { clean } from './templateWith.utils'
+
+describe('ast', () => {
+  describe('removeNamedExport', () => {
+    test.each(removeNamedExportTestCases)(
+      '$name',
+      ({ code, localName = 'namedExport' }) => {
+        const ast = babelParser.parse(code, { sourceType: 'module' })
+        const localIdentifier = removeNamedExport(
+          ast.program.body,
+          identifier('namedExport')
+        )
+
+        expect(localIdentifier).toEqual(
+          expect.objectContaining(identifier(localName))
+        )
+        expect(clean(generate(ast).code)).toMatchSnapshot()
+      }
+    )
+  })
+})

--- a/__tests__/removeNamedExport.testCases.js
+++ b/__tests__/removeNamedExport.testCases.js
@@ -1,0 +1,90 @@
+export default [
+  {
+    code: `
+    export function other() {}
+
+    export function namedExport() {}
+
+    export function last() {}
+  `,
+  },
+  {
+    code: `
+    export const other = true
+
+    export const namedExport = other
+
+    export const last = false
+    `,
+  },
+  {
+    code: `
+    export const other = true
+
+    export const before = other, namedExport = before
+
+    export const last = false
+    `,
+  },
+  {
+    code: `
+    export const other = true
+
+    export const namedExport = other, after = namedExport
+
+    export const last = false
+    `,
+  },
+  {
+    code: `
+    export const other = true
+
+    export const before = other, namedExport = before, after = namedExport
+
+    export const last = false
+    `,
+  },
+  {
+    code: `
+    function other() {}
+    export { other }
+
+    function namedExport() {}
+    export { namedExport }
+
+    function last() {}
+    export { last }
+  `,
+  },
+  {
+    code: `
+    function other() {}
+    export { other }
+
+    function localNamedExport() {}
+    export { localNamedExport as namedExport }
+
+    function last() {}
+    export { last }
+  `,
+    localName: 'localNamedExport',
+  },
+  {
+    code: `
+    function exportBefore() {}
+    function namedExport() {}
+    function exportAfter() {}
+
+    export { exportBefore, namedExport, exportAfter }
+
+    function last() {}
+    export { last }
+  `,
+  },
+].map((testCase) => ({
+  ...testCase,
+  name: testCase.code
+    .split('\n')
+    .find((line) => line.includes('export') && line.includes('namedExport'))
+    .trim(),
+}))

--- a/__tests__/templateWith.utils.js
+++ b/__tests__/templateWith.utils.js
@@ -1,12 +1,5 @@
-const specialPatternsOfReplaceMethod = ["$'", '$$', '$&', '$`']
+import prettier from 'prettier'
 
-// take each pattern and create a string including the reversed version
-// i.e. $' => '$SomeString$'
-const specialPatternsCases = specialPatternsOfReplaceMethod.map(
-  (pattern) => `${pattern.split('').reverse().join('')}SomeString${pattern}`
-)
-const nestedQuotesCases = [`".cssClass{content:' ';"`, `'Hello "world"'`]
-
-export const specialStringsRenderer = specialPatternsCases
-  .concat(nestedQuotesCases)
-  .join('\n')
+export function clean(code) {
+  return prettier.format(code, { parser: 'typescript' })
+}

--- a/__tests__/templateWithHoc.test.js
+++ b/__tests__/templateWithHoc.test.js
@@ -1,10 +1,7 @@
-import templateWithHoc from '../src/plugin/templateWithHoc'
-import { specialStringsRenderer } from './templateWith.utils'
-import prettier from 'prettier'
+import * as babelParser from '@babel/parser'
 
-function clean(code) {
-  return prettier.format(code, { parser: 'typescript' })
-}
+import templateWithHoc from '../src/plugin/templateWithHoc'
+import { clean } from './templateWith.utils'
 
 const tests = [
   {
@@ -84,7 +81,7 @@ const tests = [
   },
   {
     describe:
-      'exporting a class with a getInitialProps static | exporting apart',
+      'exporting a class with a getInitialProps static | exporting apart',
     code: `
     import React from 'react';
 
@@ -151,10 +148,7 @@ const tests = [
   `,
     cases: [{ skipInitialProps: false }, { skipInitialProps: true }],
   },
-].map((t) => {
-  t.code = specialStringsRenderer + '\n' + t.code
-  return t
-})
+]
 
 describe('templateWithHoc', () => {
   tests.forEach((d) => {
@@ -162,8 +156,18 @@ describe('templateWithHoc', () => {
       d.cases.forEach(({ expected, debug, ...options }) => {
         const fn = debug ? test.only : test
         const testname = Object.entries(options).map(([k, v]) => `${k}: ${v}`)
-        fn(testname.join(' | '), () => {
-          expect(clean(templateWithHoc(d.code, options))).toMatchSnapshot()
+        fn(testname.join(' | '), () => {
+          expect(
+            clean(
+              templateWithHoc(
+                babelParser.parse(d.code, {
+                  sourceType: 'module',
+                  plugins: ['jsx', 'typescript'],
+                }),
+                options
+              )
+            )
+          ).toMatchSnapshot()
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -103,10 +103,16 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      ".utils.js"
+      ".utils.js",
+      ".testCases.js"
     ],
     "transform": {
       "^.+\\.(j|t)sx?$": "babel-jest"
     }
+  },
+  "dependencies": {
+    "@babel/generator": "^7.17.10",
+    "@babel/parser": "^7.17.10",
+    "@babel/types": "^7.17.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "example:without-loader": "yarn build && cd examples/without-loader && yarn && yarn dev",
     "format": "pretty-quick",
     "husky": "pretty-quick --staged && yarn test",
-    "prepare": "husky install",
+    "prepare": "husky install && cross-env NODE_ENV=production && npm run tsc",
     "prepublish": "yarn test && yarn build",
     "test": "cross-env NODE_ENV=test jest --env=jsdom",
     "test:coverage": "cross-env NODE_ENV=test jest --env=jsdom --coverage",

--- a/src/plugin/ast.ts
+++ b/src/plugin/ast.ts
@@ -1,0 +1,190 @@
+import {
+  Identifier,
+  isExportNamedDeclaration,
+  isFunctionDeclaration,
+  isVariableDeclaration,
+  variableDeclaration,
+  exportNamedDeclaration,
+  isExportSpecifier,
+  StringLiteral,
+  Statement,
+  FunctionDeclaration,
+  VariableDeclaration,
+  ExportSpecifier,
+  ExportDefaultSpecifier,
+  ExportNamespaceSpecifier,
+  isImportDeclaration,
+  isImportDefaultSpecifier,
+  isImportSpecifier,
+  isStringLiteral,
+} from '@babel/types'
+
+// removes a named export and returns its local identifier
+export function removeNamedExport(
+  body: Statement[],
+  exportId: Identifier
+): Identifier | null {
+  return getNamedExport(body, exportId, (args, index) => {
+    if ('functionDeclaration' in args) {
+      body[index] = args.functionDeclaration
+      return
+    }
+
+    if ('variableDeclaration' in args) {
+      const {
+        variableDeclaration: { declarations },
+        declarationIndex,
+      } = args
+      const declaration = declarations[declarationIndex]
+
+      // add the local declaration to the program
+      body.splice(index + 1, 0, variableDeclaration('const', [declaration]))
+
+      // remove declaration, following declarations need to be made after the the new local declaration as they could depend on it
+      const [, ...remainingDeclarations] = declarations.splice(
+        declarationIndex,
+        declarations.length - declarationIndex
+      )
+      if (remainingDeclarations.length > 0) {
+        body.splice(
+          index + 2,
+          0,
+          exportNamedDeclaration(
+            variableDeclaration('const', remainingDeclarations)
+          )
+        )
+      }
+
+      if (declarations.length === 0) {
+        body.splice(index, 1)
+      }
+
+      return
+    }
+
+    if ('specifiers' in args) {
+      const { specifiers, specifierIndex } = args
+
+      if (specifiers.length > 1) {
+        specifiers.splice(specifierIndex, 1)
+      } else {
+        body.splice(index, 1)
+      }
+
+      return
+    }
+  })
+}
+
+type NamedExportMorph = (
+  params:
+    | {
+      functionDeclaration: FunctionDeclaration & { id: Identifier }
+    }
+    | {
+      variableDeclaration: VariableDeclaration
+      declarationIndex: number
+    }
+    | {
+      specifiers: (
+        | ExportSpecifier
+        | ExportDefaultSpecifier
+        | ExportNamespaceSpecifier
+      )[]
+      specifierIndex: number
+    },
+  index: number
+) => void
+
+export function getNamedExport(
+  body: Statement[],
+  exportId: Identifier,
+  morph?: NamedExportMorph
+): Identifier | null {
+  for (const index in body) {
+    const statement = body[index]
+    if (!isExportNamedDeclaration(statement)) {
+      continue
+    }
+
+    if (statement.declaration) {
+      if (
+        isFunctionDeclaration(statement.declaration) &&
+        statement.declaration.id &&
+        idsEqual(statement.declaration.id, exportId)
+      ) {
+        if (morph)
+          morph(
+            {
+              functionDeclaration:
+                statement.declaration as typeof statement.declaration & {
+                  id: Identifier
+                },
+            },
+            +index
+          )
+
+        return statement.declaration.id
+      }
+
+      if (isVariableDeclaration(statement.declaration)) {
+        const { declarations } = statement.declaration
+        for (const declarationIndex in declarations) {
+          const declaration = declarations[declarationIndex]
+
+          const { id } = declaration
+          if (id.type !== 'Identifier') {
+            continue
+          }
+
+          if (idsEqual(id, exportId)) {
+            if (morph)
+              morph(
+                {
+                  variableDeclaration: statement.declaration,
+                  declarationIndex: +declarationIndex,
+                },
+                +index
+              )
+
+            return id
+          }
+        }
+      }
+    }
+
+    for (const specifierIndex in statement.specifiers) {
+      const specifier = statement.specifiers[specifierIndex]
+      if (
+        isExportSpecifier(specifier) &&
+        idsEqual(specifier.exported, exportId)
+      ) {
+        if (morph)
+          morph(
+            {
+              specifiers: statement.specifiers,
+              specifierIndex: +specifierIndex,
+            },
+            +index
+          )
+
+        return specifier.local
+      }
+    }
+  }
+
+  return null
+}
+
+type Id = Identifier | StringLiteral | undefined | null
+function idsEqual(a: Id, b: Id) {
+  if (!a || !b) {
+    return false
+  }
+
+  return getName(a) === getName(b)
+}
+
+function getName(id: Identifier | StringLiteral) {
+  return id.type === 'StringLiteral' ? id.value : id.name
+}

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -1,3 +1,6 @@
+import { parse } from '@babel/parser'
+import { ArrowFunctionExpression, ExpressionStatement } from '@babel/types'
+
 const specFileOrFolderRgx =
   /(__mocks__|__tests__)|(\.(spec|test)\.(tsx|ts|js|jsx)$)/
 
@@ -5,6 +8,10 @@ export const clearCommentsRgx = /\/\*[\s\S]*?\*\/|\/\/.*/g
 
 export const defaultLoader =
   '(l, n) => import(`@next-translate-root/locales/${l}/${n}`).then(m => m.default)'
+
+export const defaultLoaderAst = (
+  parse(defaultLoader).program.body[0] as ExpressionStatement
+).expression as ArrowFunctionExpression
 
 export function getDefaultAppJs(hasLoadLocaleFrom: boolean) {
   return `
@@ -29,7 +36,7 @@ export function overwriteLoadLocales(exist: boolean): string {
   return `loadLocaleFrom: ${defaultLoader},`
 }
 
-export function hasExportName(data: string, name: string) {
+function hasExportName(data: string, name: string) {
   return Boolean(
     data.match(
       new RegExp(`export +(const|var|let|async +function|function) +${name}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.10.tgz#c281fa35b0c349bbe9d02916f4ae08fc85ed7189"
+  integrity sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==
+  dependencies:
+    "@babel/types" "^7.17.10"
+    "@jridgewell/gen-mapping" "^0.1.0"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz#9a1f0ebcda53d9a2d00108c4ceace6a5d5f1f08d"
@@ -241,6 +250,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
@@ -278,6 +292,11 @@
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
+
+"@babel/parser@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
+  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.2":
   version "7.16.2"
@@ -960,6 +979,14 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
+  integrity sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -1169,6 +1196,24 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/set-array@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.0.tgz#1179863356ac8fbea64a5a4bcde93a4871012c01"
+  integrity sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz#7ed98f6fa525ffb7c56a2cbecb5f7bb91abd2baf"
+  integrity sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==
 
 "@napi-rs/triples@1.0.3":
   version "1.0.3"


### PR DESCRIPTION
Currently the webpack plugin uses regular expressions for the code transformations performed. This is hard to maintain and not the most reliable solution. This RP aims to replace the RegExps with AST manipulation using `@babel/parser` and `@babel/generator`.
The only thing left to do would be to replace the `hasHOC` function with a version parsing AST, for that however I'd need some guidance towards what exactly needs to be detected as having a HOC.

Todo:
- [ ] update `hasHOC` to use AST