### PR TITLE
Fix: nested middleware detection

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,73 @@
+import { isPageToIgnore } from '../src/plugin/utils'
+
+describe('utils', () => {
+  describe('utils -> isPageToIgnore', () => {
+    const testPath = (path, expected) => {
+      const extensions = ['js', 'jsx', 'ts', 'tsx']
+      extensions.forEach((extension) => {
+        expect(isPageToIgnore(`${path}.${extension}`)).toBe(expected)
+      })
+    }
+
+    test('ignores api pages', () => {
+      testPath('/api/test', true)
+    })
+
+    test('ignores nested api pages', () => {
+      testPath('/api/nested/test', true)
+    })
+
+    test('ignores _document', () => {
+      testPath('/_document', true)
+    })
+
+    test('ignores root middleware', () => {
+      expect(isPageToIgnore(`/middleware.js`)).toBe(true)
+      expect(isPageToIgnore(`/middleware.ts`)).toBe(true)
+    })
+
+    test('ignores _middleware', () => {
+      testPath('/_middleware', true)
+    })
+
+    test('ignores nested _middleware', () => {
+      testPath('/nested/_middleware', true)
+    })
+
+    test('ignores files in __mocks__ folder', () => {
+      testPath('/__mocks__/test', true)
+    })
+
+    test('ignores files in __tests__ folder', () => {
+      testPath('/__tests__/test', true)
+    })
+
+    test('ignores .test files', () => {
+      testPath('/file.test', true)
+    })
+
+    test('ignores nested .test files', () => {
+      testPath('/nested/file.test', true)
+    })
+
+    test('ignores .spec files', () => {
+      testPath('/file.spec', true)
+    })
+
+    test('ignores nested .spec files', () => {
+      testPath('/nested/file.spec', true)
+    })
+
+    test('does not ignore _app', () => {
+      testPath('_app', false)
+    })
+
+    test('does not ignore page files', () => {
+      testPath('index', false)
+    })
+
+    test('does not ignore nested page files', () => {
+      testPath('/nested/index', false)
+    })
+  })
+})

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -41,11 +41,13 @@ export function hasExportName(data: string, name: string) {
 }
 
 export function isPageToIgnore(page: string) {
+  const fileName = page.substring(page.lastIndexOf('/') + 1)
   return Boolean(
     page.startsWith('/api/') ||
       page.startsWith('/api.') ||
       page.startsWith('/_document.') ||
-      page.startsWith('_middleware') ||
+      page.startsWith('/middleware.') ||
+      fileName.startsWith('_middleware.') ||
       page.match(specFileOrFolderRgx)
   )
 }

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -40,14 +40,14 @@ export function hasExportName(data: string, name: string) {
   )
 }
 
-export function isPageToIgnore(filePath: string) {
-  const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+export function isPageToIgnore(pageFilePath: string) {
+  const fileName = pageFilePath.substring(pageFilePath.lastIndexOf('/') + 1)
   return (
-    filePath.startsWith('/api/') ||
-    filePath.startsWith('/_document.') ||
-    filePath.startsWith('/middleware.') ||
+    pageFilePath.startsWith('/api/') ||
+    pageFilePath.startsWith('/_document.') ||
+    pageFilePath.startsWith('/middleware.') ||
     fileName.startsWith('_middleware.') ||
-    specFileOrFolderRgx.test(filePath)
+    specFileOrFolderRgx.test(pageFilePath)
   )
 }
 

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -40,15 +40,14 @@ export function hasExportName(data: string, name: string) {
   )
 }
 
-export function isPageToIgnore(page: string) {
-  const fileName = page.substring(page.lastIndexOf('/') + 1)
-  return Boolean(
-    page.startsWith('/api/') ||
-      page.startsWith('/api.') ||
-      page.startsWith('/_document.') ||
-      page.startsWith('/middleware.') ||
-      fileName.startsWith('_middleware.') ||
-      page.match(specFileOrFolderRgx)
+export function isPageToIgnore(filePath: string) {
+  const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+  return (
+    filePath.startsWith('/api/') ||
+    filePath.startsWith('/_document.') ||
+    filePath.startsWith('/middleware.') ||
+    fileName.startsWith('_middleware.') ||
+    specFileOrFolderRgx.test(filePath)
   )
 }
 


### PR DESCRIPTION
Fixes #752

https://github.com/vinissimus/next-translate/blob/49f580c6d292712a0720a104de3b487e7c11d4ae/src/plugin/utils.ts#L48

Currently the code responsible for middleware detection incorrectly assumes that we should ignore the page only if the **path** (the variable is named `page` but it actually is the file path) starts with `_middleware`. So if we place our middleware inside of a directory in the `pages` folder then the value of `page` would be `/directoryName/_middleware`, and this line would return false.

This PR fixes this problem by extracting the file name from the file path and then checking if the actual name starts with `_middleware.`. It also changes the variable name from `page` to `pageFilePath` to better represent the value we're working with and introduces a simple suite of tests for the `isPageToIgnore` function.

Due to an [upcoming change to Next](https://nextjs.org/docs/messages/middleware-upgrade-guide#no-nested-middleware), which removes the nested middleware, I have also added the new root primary middleware detection to the function (root middleware is placed directly in the `pages` folder and named `middleware.js` or `middleware.ts` - no underscore). I think we should decide whether we want to keep the support for the old middleware system (as it was in beta), or remove it and keep only the final root middleware support.