### PR TITLE
feat(format-elements): support attributes in tags and href injection

### DIFF
--- a/__tests__/formatElements.test.js
+++ b/__tests__/formatElements.test.js
@@ -1,4 +1,5 @@
-import { tagParsingRegex } from '../src/formatElements'
+import React, { Fragment } from 'react'
+import formatElements, { tagParsingRegex } from '../src/formatElements'
 
 describe('formatElements', () => {
   describe('tagParsingRegex', () => {
@@ -6,50 +7,84 @@ describe('formatElements', () => {
       const match = 'foo<p>bar</p>baz'.match(tagParsingRegex)
       expect(match[0]).toBe('<p>bar</p>')
       expect(match[1]).toBe('p')
-      expect(match[2]).toBe('bar')
-      expect(match[3]).toBe(undefined)
+      expect(match[2]).toBe('')
+      expect(match[3]).toBe('bar')
+    })
+    it('should match tags with attributes', () => {
+      const match = 'foo<a href="/bar">baz</a>qux'.match(tagParsingRegex)
+      expect(match[0]).toBe('<a href="/bar">baz</a>')
+      expect(match[1]).toBe('a')
+      expect(match[2]).toBe(' href="/bar"')
+      expect(match[3]).toBe('baz')
     })
     it('should match empty tags', () => {
       const match = 'foo<p></p>baz'.match(tagParsingRegex)
       expect(match[0]).toBe('<p></p>')
       expect(match[1]).toBe('p')
       expect(match[2]).toBe('')
-      expect(match[3]).toBe(undefined)
+      expect(match[3]).toBe('')
     })
     it('should match self closing tags without spaces', () => {
       const match = 'foo<p/>baz'.match(tagParsingRegex)
       expect(match[0]).toBe('<p/>')
-      expect(match[1]).toBe(undefined)
-      expect(match[2]).toBe(undefined)
-      expect(match[3]).toBe('p')
+      expect(match[4]).toBe('p')
+      expect(match[5]).toBe('')
     })
     it('should match self closing tags with spaces', () => {
       const match = 'foo<p />baz'.match(tagParsingRegex)
       expect(match[0]).toBe('<p />')
-      expect(match[1]).toBe(undefined)
-      expect(match[2]).toBe(undefined)
-      expect(match[3]).toBe('p')
+      expect(match[4]).toBe('p')
+      expect(match[5]).toBe(' ')
+    })
+    it('should match self closing tags with attributes', () => {
+      const match = 'foo<img src="bar.png" />baz'.match(tagParsingRegex)
+      expect(match[0]).toBe('<img src="bar.png" />')
+      expect(match[4]).toBe('img')
+      expect(match[5]).toBe(' src="bar.png" ')
     })
     it('should match first occurrence of a tag when input has several', () => {
       const match = 'foo<a>bar</a><b>baz</b>'.match(tagParsingRegex)
       expect(match[0]).toBe('<a>bar</a>')
       expect(match[1]).toBe('a')
-      expect(match[2]).toBe('bar')
-      expect(match[3]).toBe(undefined)
+      expect(match[3]).toBe('bar')
     })
     it('should match first occurrence of a tag when they are nested', () => {
       const match = 'foo<a>bar<b>baz</b>foobar</a>qux'.match(tagParsingRegex)
       expect(match[0]).toBe('<a>bar<b>baz</b>foobar</a>')
       expect(match[1]).toBe('a')
-      expect(match[2]).toBe('bar<b>baz</b>foobar')
-      expect(match[3]).toBe(undefined)
+      expect(match[3]).toBe('bar<b>baz</b>foobar')
     })
     it('should tolerate spaces in regular tags too', () => {
       const match = 'foo<a >bar</a >baz'.match(tagParsingRegex)
       expect(match[0]).toBe('<a >bar</a >')
       expect(match[1]).toBe('a')
-      expect(match[2]).toBe('bar')
-      expect(match[3]).toBe(undefined)
+      expect(match[2]).toBe(' ')
+      expect(match[3]).toBe('bar')
+    })
+  })
+
+  describe('formatElements function', () => {
+    it('should inject href from attributes into React component', () => {
+      const components = {
+        a: <a className="link" />,
+      }
+      const text = 'Click <a href="/home">here</a>'
+      const result = formatElements(text, components)
+
+      expect(result[1].type).toBe('a')
+      expect(result[1].props.href).toBe('/home')
+      expect(result[1].props.className).toBe('link')
+      expect(result[1].props.children).toBe('here')
+    })
+
+    it('should support self-closing tags with attributes', () => {
+      const components = {
+        br: <br />,
+      }
+      const text = 'line1<br />line2'
+      const result = formatElements(text, components)
+      expect(result).toHaveLength(3)
+      expect(result[1].type).toBe('br')
     })
   })
 })

--- a/src/formatElements.tsx
+++ b/src/formatElements.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement, Fragment, ReactElement, ReactNode } from 'react'
 
-export const tagParsingRegex = /<(\w+) *>(.*?)<\/\1 *>|<(\w+) *\/>/
+export const tagParsingRegex =
+  /<(\w+)((?: +[^>]*?)?)>(.*?)<\/\1 *>|<(\w+)((?: +[^>]*?)?)\/>/
 
 const nlRe = /(?:\r\n|\r|\n)/g
 
@@ -9,11 +10,19 @@ function getElements(
 ): Array<string | undefined>[] {
   if (!parts.length) return []
 
-  const [paired, children, unpaired, after] = parts.slice(0, 4)
+  const [paired, attrs, children, unpaired, unpairedAttrs, after] = parts.slice(
+    0,
+    6
+  )
 
   return [
-    [(paired || unpaired) as string, children || ('' as string), after],
-  ].concat(getElements(parts.slice(4, parts.length)))
+    [
+      (paired || unpaired) as string,
+      (attrs || unpairedAttrs) as string,
+      children || ('' as string),
+      after,
+    ],
+  ].concat(getElements(parts.slice(6, parts.length)))
 }
 
 export default function formatElements(
@@ -29,24 +38,33 @@ export default function formatElements(
   const before = parts.shift()
   if (before) tree.push(before)
 
-  getElements(parts).forEach(([key, children, after], realIndex: number) => {
-    const element =
-      // @ts-ignore
-      elements[key as string] || <Fragment />
+  getElements(parts).forEach(
+    ([key, attrs, children, after], realIndex: number) => {
+      const element =
+        // @ts-ignore
+        elements[key as string] || <Fragment />
 
-    tree.push(
-      cloneElement(
-        element,
-        { key: realIndex },
+      const props: any = { key: realIndex }
 
-        // format children for pair tags
-        // unpaired tags might have children if it's a component passed as a variable
-        children ? formatElements(children, elements) : element.props.children
+      if (attrs) {
+        const hrefMatch = attrs.match(/href=(['"])(.*?)\1/)
+        if (hrefMatch?.[2]) props.href = hrefMatch[2]
+      }
+
+      tree.push(
+        cloneElement(
+          element,
+          props,
+
+          // format children for pair tags
+          // unpaired tags might have children if it's a component passed as a variable
+          children ? formatElements(children, elements) : element.props.children
+        )
       )
-    )
 
-    if (after) tree.push(after)
-  })
+      if (after) tree.push(after)
+    }
+  )
 
   return tree
 }


### PR DESCRIPTION
Support merging attributes:

```tsx
 const components = {
    a: <a className="link" />,
 }
const text = 'Click <a href="/home">here</a>'
const result = formatElements(text, components)

expect(result[1].type).toBe('a')
expect(result[1].props.href).toBe('/home')
expect(result[1].props.className).toBe('link')
      expect(result[1].props.children).toBe('here')
```