### PR TITLE
feat: add formatElements to tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
       "types": "./createTranslation.d.ts",
       "import": "./lib/esm/createTranslation.js",
       "require": "./lib/cjs/createTranslation.js"
+    },
+    "./formatElements": {
+      "types": "./formatElements.d.ts",
+      "import": "./lib/esm/formatElements.js",
+      "require": "./lib/cjs/formatElements.js"
     }
   },
   "files": [


### PR DESCRIPTION
`formatElements` is not more internal, it can be imported and used now:

```tsx
import formatElements from 'next-translate/formatElements'
```