### PR TITLE
fix(app-router): update translation instance when locale changes

### DIFF
--- a/src/createTranslation.tsx
+++ b/src/createTranslation.tsx
@@ -19,6 +19,6 @@ export default function createTranslation(defaultNS?: string) {
     return wrapTWithDefaultNs(t, defaultNS)
   }
 
-  const t = isServer() ? getT() : useMemo(getT, [defaultNS])
+  const t = isServer() ? getT() : useMemo(getT, [defaultNS, lang])
   return { t, lang }
 }


### PR DESCRIPTION
Fixes https://github.com/aralroca/next-translate/issues/1240

The `useMemo` hook in `createTranslation` was only depending on defaultNS. In App Router, during soft navigation where components might not unmount, the translation function `t` was remaining stale with the previous language. Adding `lang` to the dependency array ensures 't' is regenerated when the locale changes.

