### PR TITLE
fix(core): ensure language updates correctly in I18nProvider and DynamicNamespaces

### DIFF
--- a/__tests__/DynamicNamespaces.test.js
+++ b/__tests__/DynamicNamespaces.test.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react'
+import { render, cleanup, fireEvent, act } from '@testing-library/react'
+import I18nProvider from '../src/I18nProvider.tsx'
+import useTranslation from '../src/useTranslation.tsx'
+import DynamicNamespaces from '../src/DynamicNamespaces.tsx'
+
+describe('DynamicNamespaces', () => {
+  afterEach(cleanup)
+
+  test('should reload namespaces when lang changes', async () => {
+    const loadLocale = jest.fn((lang, ns) => {
+      const locales = {
+        en: { common: { hello: 'Hello' } },
+        es: { common: { hello: 'Hola' } },
+      }
+      return Promise.resolve(locales[lang][ns])
+    })
+
+    const App = () => {
+      const [lang, setLang] = useState('en')
+      return (
+        <I18nProvider lang={lang} config={{ loadLocaleFrom: loadLocale }}>
+          <DynamicNamespaces namespaces={['common']}>
+            <Content />
+          </DynamicNamespaces>
+          <button onClick={() => setLang('es')}>Change to ES</button>
+        </I18nProvider>
+      )
+    }
+
+    const Content = () => {
+      const { t } = useTranslation('common')
+      return <span data-testid="text">{t('hello')}</span>
+    }
+
+    const { getByTestId, getByText } = render(<App />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getByTestId('text').textContent).toBe('Hello')
+    expect(loadLocale).toHaveBeenCalledWith('en', 'common')
+
+    await act(async () => {
+      fireEvent.click(getByText('Change to ES'))
+    })
+
+    expect(loadLocale).toHaveBeenCalledWith('es', 'common')
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getByTestId('text').textContent).toBe('Hola')
+  })
+})

--- a/__tests__/DynamicNamespaces.test.js
+++ b/__tests__/DynamicNamespaces.test.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import { render, cleanup, fireEvent, act } from '@testing-library/react'
-import I18nProvider from '../src/I18nProvider.tsx'
-import useTranslation from '../src/useTranslation.tsx'
-import DynamicNamespaces from '../src/DynamicNamespaces.tsx'
+import I18nProvider from '../src/I18nProvider'
+import useTranslation from '../src/useTranslation'
+import DynamicNamespaces from '../src/DynamicNamespaces'
 
 describe('DynamicNamespaces', () => {
   afterEach(cleanup)
@@ -53,5 +53,68 @@ describe('DynamicNamespaces', () => {
     })
 
     expect(getByTestId('text').textContent).toBe('Hola')
+  })
+
+  test('should not suffer from race conditions when lang changes rapidly', async () => {
+    let resolveES
+    const esPromise = new Promise((resolve) => {
+      resolveES = () => resolve({ hello: 'Hola' })
+    })
+
+    const loadLocale = jest.fn((lang, ns) => {
+      if (lang === 'en') return Promise.resolve({ hello: 'Hello' })
+      if (lang === 'es') return esPromise
+      return Promise.resolve({})
+    })
+
+    const App = () => {
+      const [lang, setLang] = useState('en')
+      return (
+        <I18nProvider lang={lang} config={{ loadLocaleFrom: loadLocale }}>
+          <DynamicNamespaces namespaces={['common']}>
+            <Content />
+          </DynamicNamespaces>
+          <button onClick={() => setLang('es')}>Change to ES</button>
+          <button onClick={() => setLang('en')}>Change back to EN</button>
+        </I18nProvider>
+      )
+    }
+
+    const Content = () => {
+      const { t } = useTranslation('common')
+      return <span data-testid="text">{t('hello')}</span>
+    }
+
+    const { getByTestId, getByText } = render(<App />)
+
+    // Initial load EN
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(getByTestId('text').textContent).toBe('Hello')
+
+    // Change to ES (will be pending)
+    await act(async () => {
+      fireEvent.click(getByText('Change to ES'))
+    })
+
+    // Change back to EN immediately
+    await act(async () => {
+      fireEvent.click(getByText('Change back to EN'))
+    })
+
+    // Wait for EN to resolve (it resolves instantly in our mock)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Now resolve the stale ES request
+    await act(async () => {
+      resolveES()
+      await esPromise
+    })
+
+    // It should still be 'Hello' because the ES request was stale
+    expect(getByTestId('text').textContent).toBe('Hello')
   })
 })

--- a/__tests__/I18nProvider.test.js
+++ b/__tests__/I18nProvider.test.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react'
+import { render, cleanup, fireEvent, act } from '@testing-library/react'
+import I18nProvider from '../src/I18nProvider.tsx'
+import useTranslation from '../src/useTranslation.tsx'
+
+describe('I18nProvider', () => {
+  afterEach(cleanup)
+
+  test('should update translation function when lang changes', async () => {
+    const App = () => {
+      const [lang, setLang] = useState('en')
+      const namespaces =
+        lang === 'en'
+          ? { common: { hello: 'Hello' } }
+          : { common: { hello: 'Hola' } }
+
+      return (
+        <I18nProvider lang={lang} namespaces={namespaces}>
+          <Content />
+          <button onClick={() => setLang('es')}>Change to ES</button>
+        </I18nProvider>
+      )
+    }
+
+    const Content = () => {
+      const { t, lang } = useTranslation('common')
+      return (
+        <div>
+          <span data-testid="lang">{lang}</span>
+          <span data-testid="text">{t('hello')}</span>
+        </div>
+      )
+    }
+
+    const { getByTestId, getByText } = render(<App />)
+
+    expect(getByTestId('lang').textContent).toBe('en')
+    expect(getByTestId('text').textContent).toBe('Hello')
+
+    await act(async () => {
+      fireEvent.click(getByText('Change to ES'))
+    })
+
+    expect(getByTestId('lang').textContent).toBe('es')
+    expect(getByTestId('text').textContent).toBe('Hola')
+  })
+})

--- a/src/DynamicNamespaces.tsx
+++ b/src/DynamicNamespaces.tsx
@@ -28,7 +28,7 @@ export default function DynamicNamespaces({
 
   useEffect(() => {
     loadNamespaces()
-  }, [namespaces.join()])
+  }, [namespaces.join(), lang])
 
   if (!loaded) return fallback || null
 

--- a/src/DynamicNamespaces.tsx
+++ b/src/DynamicNamespaces.tsx
@@ -16,18 +16,27 @@ export default function DynamicNamespaces({
   const loadLocale =
     dynamic || config.loadLocaleFrom || (() => Promise.resolve({}))
 
-  async function loadNamespaces() {
-    if (typeof loadLocale !== 'function') return
-
-    const pageNamespaces = await Promise.all(
-      namespaces.map((ns) => loadLocale(lang, ns))
-    )
-    setPageNs(pageNamespaces)
-    setLoaded(true)
-  }
-
   useEffect(() => {
+    let isCancelled = false
+
+    async function loadNamespaces() {
+      if (typeof loadLocale !== 'function') return
+
+      const pageNamespaces = await Promise.all(
+        namespaces.map((ns) => loadLocale(lang, ns))
+      )
+
+      if (isCancelled) return
+
+      setPageNs(pageNamespaces)
+      setLoaded(true)
+    }
+
     loadNamespaces()
+
+    return () => {
+      isCancelled = true
+    }
   }, [namespaces.join(), lang])
 
   if (!loaded) return fallback || null

--- a/src/I18nProvider.tsx
+++ b/src/I18nProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import I18nContext from './context'
 import transCore from './transCore'
@@ -25,8 +25,14 @@ export default function I18nProvider({
   const config = { ...internal.config, ...newConfig }
   const localesToIgnore = config.localesToIgnore || ['default']
   const ignoreLang = !lang || localesToIgnore.includes(lang)
-  const pluralRules = new Intl.PluralRules(ignoreLang ? undefined : lang)
-  const t = transCore({ config, allNamespaces, pluralRules, lang })
+  const pluralRules = useMemo(
+    () => new Intl.PluralRules(ignoreLang ? undefined : lang),
+    [ignoreLang, lang]
+  )
+  const t = useMemo(
+    () => transCore({ config, allNamespaces, pluralRules, lang }),
+    [config, allNamespaces, pluralRules, lang]
+  )
 
   return (
     <I18nContext.Provider value={{ lang, t }}>


### PR DESCRIPTION
Fixes https://github.com/aralroca/next-translate/issues/1257
Fixes https://github.com/aralroca/next-translate/issues/1258

This fix addresses a bug where the application language would not update after a change to the `lang` prop in `I18nProvider`.

Technical Explanation:
1. I18nProvider: By wrapping `pluralRules` and the `t` function in `useMemo` with `lang` and `namespaces` as dependencies, we ensure these values are re-calculated whenever the language or the loaded namespaces change. Without this, the context might provide a stale translation function that still uses the previous language's state.
2. DynamicNamespaces: Included `lang` in the `useEffect` dependency array to trigger a re-load of namespaces when the global language changes.

Verification:
- Added regression tests in `I18nProvider.test.js` and `DynamicNamespaces.test.js`.
- All 146 tests passed.
