### PR TITLE
fix(app-router): prevent AppDirI18nProvider from overwriting loadLocaleFrom on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,37 @@ Remember that `['dynamic']` namespace should **not** be listed on `pages` config
   }
 ```
 
+**Using DynamicNamespaces with App Router (app directory)**
+
+In the App Router, the `loadLocaleFrom` function from your `i18n.js` config is not available on the client side (it gets lost during RSC → Client Component serialization). You need to pass a `dynamic` prop with a loader function:
+
+```jsx
+'use client'
+
+import DynamicNamespaces from 'next-translate/DynamicNamespaces'
+import useTranslation from 'next-translate/useTranslation'
+
+const loadLocaleFrom = (lang, ns) =>
+  import(`../../../locales/${lang}/${ns}.json`).then((m) => m.default || m)
+
+function ToolContent() {
+  const { t } = useTranslation('tools/my-tool')
+  return <h1>{t('title')}</h1>
+}
+
+export default function MyComponent() {
+  return (
+    <DynamicNamespaces
+      dynamic={loadLocaleFrom}
+      namespaces={['tools/my-tool']}
+      fallback="Loading..."
+    >
+      <ToolContent />
+    </DynamicNamespaces>
+  )
+}
+```
+
 - **Props**:
   - `namespaces` - string[] - list of dynamic namespaces to download - **Required**.
   - `fallback`- ReactNode - Fallback to display meanwhile the namespaces are loading. - **Optional**.

--- a/__tests__/AppDirI18nProvider.test.js
+++ b/__tests__/AppDirI18nProvider.test.js
@@ -1,0 +1,113 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import AppDirI18nProvider from '../src/AppDirI18nProvider'
+import getT from '../src/getT'
+
+describe('AppDirI18nProvider', () => {
+  const originalWindow = global.window
+
+  afterEach(() => {
+    global.window = originalWindow
+    delete globalThis.__NEXT_TRANSLATE__
+    delete global.i18nConfig
+  })
+
+  describe('on the server (window is undefined)', () => {
+    beforeEach(() => {
+      delete global.window
+    })
+
+    afterEach(() => {
+      global.window = originalWindow
+    })
+
+    test('should NOT overwrite globalThis.__NEXT_TRANSLATE__ on the server', () => {
+      const loadLocaleFrom = jest.fn()
+      const serverConfig = {
+        loadLocaleFrom,
+        keySeparator: false,
+      }
+
+      // Simulate what the RSC wrapper (templateAppDir) does before rendering:
+      // it sets globalThis.__NEXT_TRANSLATE__ with the full config including functions
+      globalThis.__NEXT_TRANSLATE__ = {
+        lang: 'en',
+        namespaces: { common: { title: 'Hello' } },
+        config: serverConfig,
+      }
+
+      // AppDirI18nProvider receives a serialized config (JSON.parse(JSON.stringify()))
+      // which strips functions like loadLocaleFrom
+      const serializedConfig = JSON.parse(JSON.stringify(serverConfig))
+
+      // Call the component directly (as happens during SSR)
+      AppDirI18nProvider({
+        lang: 'en',
+        namespaces: { common: { title: 'Hello' } },
+        config: serializedConfig,
+        children: React.createElement('div'),
+      })
+
+      // The config in globalThis should still have loadLocaleFrom
+      expect(globalThis.__NEXT_TRANSLATE__.config.loadLocaleFrom).toBe(
+        loadLocaleFrom
+      )
+    })
+
+    test('getT should resolve translations after AppDirI18nProvider renders on server', async () => {
+      const loadLocaleFrom = jest
+        .fn()
+        .mockImplementation((lang, ns) =>
+          Promise.resolve({ 'meta.title': 'My Site Title' })
+        )
+
+      const serverConfig = {
+        loadLocaleFrom,
+        keySeparator: false,
+      }
+
+      // 1. RSC wrapper sets globalThis with full config (as templateAppDir does)
+      globalThis.__NEXT_TRANSLATE__ = {
+        lang: 'en',
+        namespaces: { common: { 'meta.title': 'My Site Title' } },
+        config: serverConfig,
+      }
+
+      // 2. AppDirI18nProvider runs on the server with serialized config (functions stripped)
+      const serializedConfig = JSON.parse(JSON.stringify(serverConfig))
+      AppDirI18nProvider({
+        lang: 'en',
+        namespaces: { common: { 'meta.title': 'My Site Title' } },
+        config: serializedConfig,
+        children: React.createElement('div'),
+      })
+
+      // 3. A subsequent getT call (e.g. from generateMetadata during soft navigation)
+      //    should still resolve translations, not return the raw key
+      const t = await getT('en', 'common')
+      expect(t('meta.title')).toBe('My Site Title')
+    })
+  })
+
+  describe('on the client (window is defined)', () => {
+    test('should set globalThis.__NEXT_TRANSLATE__ on the client', () => {
+      const config = { keySeparator: '.' }
+      const namespaces = { common: { title: 'Hello' } }
+
+      render(
+        React.createElement(AppDirI18nProvider, {
+          lang: 'en',
+          namespaces,
+          config,
+          children: React.createElement('div'),
+        })
+      )
+
+      expect(globalThis.__NEXT_TRANSLATE__).toEqual({
+        lang: 'en',
+        namespaces,
+        config,
+      })
+    })
+  })
+})

--- a/src/AppDirI18nProvider.tsx
+++ b/src/AppDirI18nProvider.tsx
@@ -20,7 +20,16 @@ export default function AppDirI18nProvider({
   config,
   children,
 }: AppDirI18nProviderProps) {
-  globalThis.__NEXT_TRANSLATE__ = { lang, namespaces, config }
+  // On the server, the RSC wrapper (templateAppDir) already sets
+  // globalThis.__NEXT_TRANSLATE__ with the full config including
+  // non-serializable properties like loadLocaleFrom.
+  // The config prop here has been serialized via JSON.parse(JSON.stringify()),
+  // which strips functions. Setting it on the server would overwrite the
+  // correct config and break subsequent getT() calls (e.g. in generateMetadata)
+  // that rely on loadLocaleFrom to dynamically load translations.
+  if (typeof window !== 'undefined') {
+    globalThis.__NEXT_TRANSLATE__ = { lang, namespaces, config }
+  }
 
   // It return children and avoid re-renders and also allow children to be RSC (React Server Components)
   return children


### PR DESCRIPTION
When using the App Router, the RSC wrapper generated by next-translate-plugin
(`templateAppDir`) correctly sets `globalThis.__NEXT_TRANSLATE__` with the full
i18n config, including non-serializable properties like `loadLocaleFrom`.

However, `AppDirI18nProvider` receives its config prop via
`JSON.parse(JSON.stringify(config))`, which strips all functions. Since
`AppDirI18nProvider` is a `'use client'` component that also executes during SSR,
it was unconditionally overwriting `globalThis.__NEXT_TRANSLATE__` with the
serialized (function-stripped) config.

This caused a bug during client-side (soft) navigation: when `generateMetadata`
in a layout calls `getT()`, it reads `globalThis.__NEXT_TRANSLATE__.config`, which
no longer has `loadLocaleFrom`. Without that loader, `getT` falls back to a
default loader that returns an empty dictionary, so `t('some.key')` returns the
raw key instead of the translated string.

On a full page refresh the issue did not reproduce because the dev server
re-evaluates modules, resetting `globalThis.__NEXT_TRANSLATE__` to `undefined`,
which makes `getT` fall back to `getConfig()` — where `loadLocaleFrom` is intact.

**The fix:** only set `globalThis.__NEXT_TRANSLATE__` inside `AppDirI18nProvider` when
running on the client (`typeof window !== 'undefined'`). On the server, the RSC
wrapper already sets it correctly, so the provider does not need to touch it.

Fixes #1020