### PR TITLE
fix: prevent cross-locale namespace pollution during static builds

### DIFF
--- a/__tests__/AppDirI18nProvider.test.js
+++ b/__tests__/AppDirI18nProvider.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import AppDirI18nProvider from '../src/AppDirI18nProvider'
-import getT from '../src/getT'
 
 describe('AppDirI18nProvider', () => {
   const originalWindow = global.window
@@ -21,71 +20,22 @@ describe('AppDirI18nProvider', () => {
       global.window = originalWindow
     })
 
-    test('should NOT overwrite globalThis.__NEXT_TRANSLATE__ on the server', () => {
-      const loadLocaleFrom = jest.fn()
-      const serverConfig = {
-        loadLocaleFrom,
-        keySeparator: false,
-      }
+    test('should set globalThis.__NEXT_TRANSLATE__ on the server', () => {
+      const config = { keySeparator: false }
+      const namespaces = { common: { title: 'Hello' } }
 
-      // Simulate what the RSC wrapper (templateAppDir) does before rendering:
-      // it sets globalThis.__NEXT_TRANSLATE__ with the full config including functions
-      globalThis.__NEXT_TRANSLATE__ = {
-        lang: 'en',
-        namespaces: { common: { title: 'Hello' } },
-        config: serverConfig,
-      }
-
-      // AppDirI18nProvider receives a serialized config (JSON.parse(JSON.stringify()))
-      // which strips functions like loadLocaleFrom
-      const serializedConfig = JSON.parse(JSON.stringify(serverConfig))
-
-      // Call the component directly (as happens during SSR)
       AppDirI18nProvider({
         lang: 'en',
-        namespaces: { common: { title: 'Hello' } },
-        config: serializedConfig,
+        namespaces,
+        config,
         children: React.createElement('div'),
       })
 
-      // The config in globalThis should still have loadLocaleFrom
-      expect(globalThis.__NEXT_TRANSLATE__.config.loadLocaleFrom).toBe(
-        loadLocaleFrom
-      )
-    })
-
-    test('getT should resolve translations after AppDirI18nProvider renders on server', async () => {
-      const loadLocaleFrom = jest
-        .fn()
-        .mockImplementation((lang, ns) =>
-          Promise.resolve({ 'meta.title': 'My Site Title' })
-        )
-
-      const serverConfig = {
-        loadLocaleFrom,
-        keySeparator: false,
-      }
-
-      // 1. RSC wrapper sets globalThis with full config (as templateAppDir does)
-      globalThis.__NEXT_TRANSLATE__ = {
+      expect(globalThis.__NEXT_TRANSLATE__).toEqual({
         lang: 'en',
-        namespaces: { common: { 'meta.title': 'My Site Title' } },
-        config: serverConfig,
-      }
-
-      // 2. AppDirI18nProvider runs on the server with serialized config (functions stripped)
-      const serializedConfig = JSON.parse(JSON.stringify(serverConfig))
-      AppDirI18nProvider({
-        lang: 'en',
-        namespaces: { common: { 'meta.title': 'My Site Title' } },
-        config: serializedConfig,
-        children: React.createElement('div'),
+        namespaces,
+        config,
       })
-
-      // 3. A subsequent getT call (e.g. from generateMetadata during soft navigation)
-      //    should still resolve translations, not return the raw key
-      const t = await getT('en', 'common')
-      expect(t('meta.title')).toBe('My Site Title')
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
       "types": "./formatElements.d.ts",
       "import": "./lib/esm/formatElements.js",
       "require": "./lib/cjs/formatElements.js"
+    },
+    "./i18nRequestStore": {
+      "types": "./i18nRequestStore.d.ts",
+      "import": "./lib/esm/i18nRequestStore.js",
+      "require": "./lib/cjs/i18nRequestStore.js"
     }
   },
   "files": [
@@ -124,12 +129,13 @@
     "index",
     "AppDirI18nProvider",
     "createTranslation",
-    "formatElements"
+    "formatElements",
+    "i18nRequestStore"
   ],
   "scripts": {
     "build": "yarn clean && cross-env NODE_ENV=production && yarn tsc",
     "clean": "yarn clean:build && yarn clean:examples",
-    "clean:build": "del lib appWith* Dynamic* I18n* index context loadNa* setLang* Trans* useT* withT* getP* getC* *.d.ts getT transC* wrapT* types formatElements isServer AppDirI18nProvider* createTrans*",
+    "clean:build": "del lib appWith* Dynamic* I18n* i18nStore* i18nRequestStore* index context loadNa* setLang* Trans* useT* withT* getP* getC* *.d.ts getT transC* wrapT* types formatElements isServer AppDirI18nProvider* createTrans*",
     "clean:examples": "del examples/**/.next examples/**/node_modules examples/**/yarn.lock",
     "example": "yarn example:complex",
     "example:basic": "yarn build && yarn --cwd examples/basic && yarn --cwd examples/basic dev",

--- a/src/AppDirI18nProvider.tsx
+++ b/src/AppDirI18nProvider.tsx
@@ -20,16 +20,7 @@ export default function AppDirI18nProvider({
   config,
   children,
 }: AppDirI18nProviderProps) {
-  // On the server, the RSC wrapper (templateAppDir) already sets
-  // globalThis.__NEXT_TRANSLATE__ with the full config including
-  // non-serializable properties like loadLocaleFrom.
-  // The config prop here has been serialized via JSON.parse(JSON.stringify()),
-  // which strips functions. Setting it on the server would overwrite the
-  // correct config and break subsequent getT() calls (e.g. in generateMetadata)
-  // that rely on loadLocaleFrom to dynamically load translations.
-  if (typeof window !== 'undefined') {
-    globalThis.__NEXT_TRANSLATE__ = { lang, namespaces, config }
-  }
+  globalThis.__NEXT_TRANSLATE__ = { lang, namespaces, config }
 
   // It return children and avoid re-renders and also allow children to be RSC (React Server Components)
   return children

--- a/src/i18nRequestStore.tsx
+++ b/src/i18nRequestStore.tsx
@@ -1,0 +1,27 @@
+import { I18nDictionary } from '.'
+
+type NamespaceStore = Record<string, I18nDictionary>
+
+// React.cache creates a per-request memoized function (React 19+).
+// Each static page render during `next build` gets its own cached store,
+// preventing cross-locale namespace pollution via globalThis.
+let createRequestStore: () => NamespaceStore
+
+try {
+  const React = require('react')
+  if (typeof React.cache === 'function') {
+    createRequestStore = React.cache((): NamespaceStore => ({}))
+  }
+} catch {}
+
+// @ts-ignore - fallback for React 18 or non-RSC contexts
+if (!createRequestStore) {
+  // Without React.cache, fall back to copying from globalThis (current behavior)
+  createRequestStore = () => ({
+    ...(globalThis.__NEXT_TRANSLATE__?.namespaces ?? {}),
+  })
+}
+
+export function getRequestNamespaces(): NamespaceStore {
+  return createRequestStore()
+}


### PR DESCRIPTION
Fixes #1219

During `next build`, globalThis.__NEXT_TRANSLATE__ is shared across all locale renders in the same process. When building pages for multiple locales, stale namespaces from one locale leak into another.

Add i18nRequestStore using React.cache (React 19+) to create a per-render-request namespace accumulator. Each locale render gets its own isolated store, preventing cross-locale pollution. Falls back to globalThis for React 18 compatibility.

Also reverts the `if (typeof window !== 'undefined')` guard in AppDirI18nProvider that was breaking production builds.

This PR depends on https://github.com/aralroca/next-translate-plugin/pull/96