### PR TITLE
fix: match page namespaces ignoring App Router route groups (#1263)

### DIFF
--- a/__tests__/getPageNamespaces.test.js
+++ b/__tests__/getPageNamespaces.test.js
@@ -78,6 +78,62 @@ describe('getPageNamespaces', () => {
     })
   })
 
+  describe('route groups', () => {
+    test('should match pages config with route group when page path has no route group', async () => {
+      const config = {
+        pages: {
+          '*': ['common'],
+          '/[lang]/(main)/blog/[slug]': ['blog'],
+        },
+      }
+      const output = await getPageNamespaces(config, '/[lang]/blog/[slug]', ctx)
+
+      expect(output).toContain('common')
+      expect(output).toContain('blog')
+    })
+
+    test('should match pages config without route group when page path has route group', async () => {
+      const config = {
+        pages: {
+          '/[lang]/blog/[slug]': ['blog'],
+        },
+      }
+      const output = await getPageNamespaces(
+        config,
+        '/[lang]/(main)/blog/[slug]',
+        ctx
+      )
+
+      expect(output).toContain('blog')
+    })
+
+    test('should match when both config and page have different route groups', async () => {
+      const config = {
+        pages: {
+          '/[lang]/(auth)/dashboard': ['dashboard'],
+        },
+      }
+      const output = await getPageNamespaces(
+        config,
+        '/[lang]/(admin)/dashboard',
+        ctx
+      )
+
+      expect(output).toContain('dashboard')
+    })
+
+    test('should match with multiple route groups in path', async () => {
+      const config = {
+        pages: {
+          '/[lang]/(main)/(protected)/settings': ['settings'],
+        },
+      }
+      const output = await getPageNamespaces(config, '/[lang]/settings', ctx)
+
+      expect(output).toContain('settings')
+    })
+  })
+
   describe('as function', () => {
     test('should work as a fn', async () => {
       ctx.query.example = '1'

--- a/src/getPageNamespaces.tsx
+++ b/src/getPageNamespaces.tsx
@@ -6,6 +6,15 @@ function flat(a: string[][]): string[] {
 }
 
 /**
+ * Strip Next.js App Router route groups from a path.
+ * Route groups are path segments wrapped in parentheses, e.g. /(main)/
+ * They are used for layout organization but don't affect the URL.
+ */
+function stripRouteGroups(path: string): string {
+  return path.replace(/\/\([^)]+\)/g, '')
+}
+
+/**
  * Get page namespaces
  *
  * @param {object} config
@@ -20,6 +29,8 @@ export default async function getPageNamespaces(
   const getNs = async (ns: PageValue): Promise<string[]> =>
     typeof ns === 'function' ? ns(ctx) : ns || []
 
+  const normalizedPage = stripRouteGroups(page)
+
   // Namespaces promises using regex
   const rgxs = Object.keys(pages).reduce((arr: Promise<string[]>[], p) => {
     if (
@@ -31,9 +42,21 @@ export default async function getPageNamespaces(
     return arr
   }, [])
 
+  // Try exact match first, then match by stripping route groups from both sides
+  let pageNs = pages[page]
+  if (!pageNs) {
+    const match = Object.keys(pages).find(
+      (p) =>
+        p !== '*' &&
+        !p.startsWith(rgx) &&
+        stripRouteGroups(p) === normalizedPage
+    )
+    if (match) pageNs = pages[match]
+  }
+
   return [
     ...(await getNs(pages['*'])),
-    ...(await getNs(pages[page])),
+    ...(await getNs(pageNs)),
     ...flat(await Promise.all(rgxs)),
   ]
 }


### PR DESCRIPTION
Fixes #1263

`getPageNamespaces` used exact path matching, so pages configured with route groups (e.g. `/[lang]/(main)/blog/[slug]`) would not match when the pathname lacked the group segment, and vice-versa.  Strip `/(…)` segments from both sides before comparing, preserving the fast exact lookup as the first attempt.


