### PR TITLE
fix: update t when the loaded namespace set changes

### DIFF
--- a/__tests__/createTranslation.test.js
+++ b/__tests__/createTranslation.test.js
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import createTranslation from '../src/createTranslation'
+
+describe('createTranslation', () => {
+  afterEach(cleanup)
+  beforeAll(() => {
+    console.warn = jest.fn()
+  })
+
+  test('refreshes t when the namespace set changes (client-side navigation)', () => {
+    // First SSR page only loaded "ns1".
+    globalThis.__NEXT_TRANSLATE__ = {
+      lang: 'en',
+      namespaces: { ns1: { key: 'from ns1' } },
+      config: {},
+    }
+
+    // A long-lived holder that never unmounts (mimics a translation function
+    // lifted to _app / a context provider in the Pages Router).
+    const Holder = () => {
+      const [, rerender] = useState(0)
+      const { t } = createTranslation()
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              // Client-side navigation loads a new page whose namespace set is "ns2".
+              globalThis.__NEXT_TRANSLATE__ = {
+                lang: 'en',
+                namespaces: { ns2: { key: 'from ns2' } },
+                config: {},
+              }
+              rerender((x) => x + 1)
+            }}
+          >
+            navigate
+          </button>
+          <span data-testid="out">{t('ns2:key')}</span>
+        </>
+      )
+    }
+
+    const { getByText, getByTestId } = render(<Holder />)
+
+    // "ns2" is not loaded yet, so the key is returned untranslated.
+    expect(getByTestId('out').textContent).toBe('ns2:key')
+
+    fireEvent.click(getByText('navigate'))
+
+    // After navigation "ns2" is loaded; the memoized t must pick up the new
+    // namespace set even though defaultNS and lang are unchanged.
+    expect(getByTestId('out').textContent).toBe('from ns2')
+  })
+
+  test('keeps a stable t reference across re-renders when the namespace set is unchanged', () => {
+    globalThis.__NEXT_TRANSLATE__ = {
+      lang: 'en',
+      namespaces: { ns1: { key: 'from ns1' } },
+      config: {},
+    }
+
+    const seen = []
+
+    const Holder = () => {
+      const [, rerender] = useState(0)
+      const { t } = createTranslation()
+      seen.push(t)
+      return (
+        <button type="button" onClick={() => rerender((x) => x + 1)}>
+          rerender
+        </button>
+      )
+    }
+
+    const { getByText } = render(<Holder />)
+    fireEvent.click(getByText('rerender'))
+
+    // Identity must stay stable when nothing relevant changed (see #447).
+    expect(seen.length).toBeGreaterThanOrEqual(2)
+    expect(seen[seen.length - 1]).toBe(seen[0])
+  })
+})

--- a/src/createTranslation.tsx
+++ b/src/createTranslation.tsx
@@ -20,6 +20,14 @@ export default function createTranslation(defaultNS?: string) {
     return wrapTWithDefaultNs(t, defaultNS)
   }
 
-  const t = isServer() ? getT() : useMemo(getT, [defaultNS, lang])
+  // A stable signature of the currently loaded namespace set. In the Pages
+  // Router the appWithI18n HoC reassigns globalThis.__NEXT_TRANSLATE__ on every
+  // navigation, so a translation function held by a component that never
+  // unmounts (e.g. lifted to _app or a context provider) would otherwise stay
+  // memoized on the first page's namespaces and miss namespaces loaded later.
+  // Keying on the namespace names refreshes t when the set actually changes,
+  // while keeping its identity stable otherwise (#447).
+  const nsKey = namespaces ? Object.keys(namespaces).sort().join('|') : ''
+  const t = isServer() ? getT() : useMemo(getT, [defaultNS, lang, nsKey])
   return { t, lang }
 }


### PR DESCRIPTION
Closes #1268.

## What & why

Since v3, `useTranslation` delegates to `createTranslation` whenever `globalThis.__NEXT_TRANSLATE__` is set. In the **Pages Router**, `appWithI18n` now sets that global on every render, so `createTranslation` is used there too — not only in the App Router.

`createTranslation` memoizes `t` with `useMemo(getT, [defaultNS, lang])`. `getT` closes over `namespaces` (read from the global), but `namespaces` is not in the dependency array. For a translation function held by a component that does **not** unmount across navigations — e.g. lifted into `_app` or a context provider and passed down — the memo never recomputes (same `defaultNS`/`lang`), so `t` stays bound to the **first** page's namespaces. After a client-side navigation, pages whose namespace set differs then render keys instead of translations. A full reload/SSR hides it because the holder remounts; components that call `useTranslation` themselves are unaffected because they remount on navigation.

## Fix

Add a stable signature of the namespace names to the memo deps. `t` refreshes when the namespace **set** actually changes, while keeping a stable identity otherwise — preserving the stability expected by consumers that put `t` in dependency arrays (#447).

```ts
const nsKey = namespaces ? Object.keys(namespaces).sort().join("|") : "";
const t = isServer() ? getT() : useMemo(getT, [defaultNS, lang, nsKey]);
```

## Tests

Added `__tests__/createTranslation.test.js`:

- **fails before this change**: `t` refreshes when the namespace set changes across a re-render of a non-unmounting holder.
- guards #447: `t` keeps a stable reference when the namespace set is unchanged.

Full suite passes (14 suites / 161 tests), `tsc` and Prettier clean.

Targets `canary` per CONTRIBUTING.
